### PR TITLE
Add LLM Usage Policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ For new features or architectural changes:
 - **Linting & Formatting**: Follow the existing code style and formatting conventions used in the files you are editing. If the package you are changing defines linting or formatting scripts, run those before submitting code.
 - **Testing**: Ensure that logic changes are covered by tests, and run the relevant test commands for the packages you modify (see their documentation or `package.json`).
 - **Component Design**: Follow functional component patterns and ensure that UI state is managed predictably within the monorepo structure.
-- **New package creation**: If a new package needs to be created, please follow the standards used by the existing packages, including the standard commands `build:dev`, `build:prod`, `test`, `e2e-test`, `lint`
+- **New package creation**: If a new package needs to be created, please follow the standards used by the existing packages, including the standard commands `build:dev`, `build:prod`, `test`, `e2e-test`, `lint`.
 
 ## LLM Usage Policy
 
@@ -89,7 +89,7 @@ To ensure a healthy and productive community, the following expectations apply:
 
 ### Acceptable Use of LLMs
 
-- LLMs may be used to **assist your development** — e.g. drafting code, writing documentation, proposing fixes — as long as **you understand, validate**, and **take responsibility for the results.**
+- LLMs may be used to **assist your development** — e.g., drafting code, writing documentation, proposing fixes — as long as **you understand, validate**, and **take responsibility for the results.**
 - You should only submit contributions (PRs, comments, discussions, issues) that reflect your **own understanding** and **intent**, not what an Agent/LLM "spit out."
 - You may use Agents/LLMs to help you **write better**, but not to **post more**.
 
@@ -107,9 +107,9 @@ To ensure a healthy and productive community, the following expectations apply:
 
 ### If in Doubt
 
-If you're unsure whether your use of Agents/LLMs is acceptable - ask! We're happy to help contributors learn how to use AI tools effectively **without creating noise**.
+If you're unsure whether your use of Agents/LLMs is acceptable — ask! We're happy to help contributors learn how to use AI tools effectively **without creating noise**.
 
-> This isn’t about banning AI - it’s about keeping this project collaborative, human-driven, and focused on quality.
+> This isn't about banning AI — it's about keeping this project collaborative, human-driven, and focused on quality.
 
 ## Pull Request Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,31 +83,30 @@ For new features or architectural changes:
 
 ## LLM Usage Policy
 
-In this project, we welcome tools that help developers become more productive — including Large Language Models (LLMs) and Agents like ChatGPT, GitHub Copilot, and others.
+In this project, we welcome tools that help developers become more productive — including Large Language Models (LLMs) and agents like ChatGPT, GitHub Copilot, and others. To ensure a healthy and productive community, the following expectations apply:
 
-To ensure a healthy and productive community, the following expectations apply:
+- Use LLMs to **assist your development** — drafting code, writing docs, proposing fixes — as long as you **understand, validate, and take responsibility** for the results.
+- Only submit contributions that reflect your **own understanding and intent**.
+- You may use LLMs to help you **write better**, but not to **post more**.
 
-### Acceptable Use of LLMs
+### Requirements
 
-- LLMs may be used to **assist your development** — e.g., drafting code, writing documentation, proposing fixes — as long as **you understand, validate**, and **take responsibility for the results.**
-- You should only submit contributions (PRs, comments, discussions, issues) that reflect your **own understanding** and **intent**, not what an Agent/LLM "spit out."
-- You may use Agents/LLMs to help you **write better**, but not to **post more**.
-
-### Unacceptable Use
-
-- Submitting code, tests, comments, or issues that appear to be **copied directly from an LLM with little or no human oversight** is **not acceptable**.
-- Posting **large volumes of low-effort suggestions, vague issues, or links with no context** — even if technically accurate — is considered spam.
-- Submitting **AI-generated tests that do not validate actual behavior** or meaningfully cover functionality is not helpful and will be rejected.
-- Using bots, agents, or automated tools to open PRs, file issues, or post content **without human authorship and responsibility** is not allowed.
+- Verify behavior, correctness, and compatibility yourself before submitting. Do not ask maintainers to do this for you.
+- Keep changes narrow and focused. Posting large volumes of low-effort suggestions, vague issues, or links with no context — even if technically accurate — is considered spam.
+- Do **NOT** submit code, tests, comments, or issues that are copied directly from an LLM with little or no human oversight. Be prepared to explain all the changes yourself.
+- Do **NOT** submit AI-generated tests that do not validate actual behavior or meaningfully cover functionality.
+- Do **NOT** use bots, agents, or automated tools to open PRs, file issues, or post content without human authorship and responsibility.
+- Do **NOT** include private code, credentials, tokens, or confidential material.
+- Respect licensing and attribution requirements.
 
 ### Consequences
 
-- We may close issues, PRs, or discussions that violate this policy without detailed explanation.
-- Repeated violations may result in temporary or permanent restrictions from participating in the project.
+1. We may close issues, PRs, or discussions that violate this policy without detailed explanation.
+2. Repeated violations may result in temporary or permanent restrictions from participating in the project.
 
 ### If in Doubt
 
-If you're unsure whether your use of Agents/LLMs is acceptable — ask! We're happy to help contributors learn how to use AI tools effectively **without creating noise**.
+If you're unsure whether your use of agents/LLMs is acceptable — ask! We're happy to help contributors learn how to use AI tools effectively **without creating noise**.
 
 > This isn't about banning AI — it's about keeping this project collaborative, human-driven, and focused on quality.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 <!--
    Copyright 2021-Present The Serverless Workflow Specification Authors
-  
+
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
-  
+
    http://www.apache.org/licenses/LICENSE-2.0
-  
+
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,6 +25,7 @@ This project is the official, vendor-neutral visual editor for the [Serverless W
 ## Prerequisites
 
 To build and run the editor locally, you will need:
+
 - **Node.js** (current LTS version; see https://nodejs.org/)
 - **pnpm**
 
@@ -51,14 +52,15 @@ pnpm run build:prod
 
 This project uses the following core technology stack:
 
-* **Language**: [TypeScript](https://www.typescriptlang.org/) (for type safety and maintainability)
-* **Library**: [React](https://react.dev/) (for building the user interface)
+- **Language**: [TypeScript](https://www.typescriptlang.org/) (for type safety and maintainability)
+- **Library**: [React](https://react.dev/) (for building the user interface)
 
 The project aims for the editor to be **embeddable**, with the core logic decoupled from specific platform APIs (like VS Code or Chrome APIs) through an abstraction layer.
 
 ## Reporting an Issue
 
 If you find a bug or have a question, please check the [existing issues](https://github.com/serverlessworkflow/editor/issues) first.
+
 1. Open a new issue using the appropriate template.
 2. Provide a clear description of the problem.
 3. Include steps to reproduce the bug and provide a sample workflow file (`.sw.json` or `.sw.yaml`) if applicable.
@@ -66,17 +68,48 @@ If you find a bug or have a question, please check the [existing issues](https:/
 ## Suggesting a Change
 
 For new features or architectural changes:
+
 1. Open an **Issue** or a **GitHub Discussion** to propose your idea.
 2. Ensure the proposal aligns with the goals of being **vendor-neutral** and **specification-first**.
 3. Once the approach is agreed upon by maintainers, you may proceed with a Pull Request.
 
 ## Coding Standards
 
-* **TypeScript**: Always use strict typing. Avoid `any`.
-* **Linting & Formatting**: Follow the existing code style and formatting conventions used in the files you are editing. If the package you are changing defines linting or formatting scripts, run those before submitting code.
-* **Testing**: Ensure that logic changes are covered by tests, and run the relevant test commands for the packages you modify (see their documentation or `package.json`).
-* **Component Design**: Follow functional component patterns and ensure that UI state is managed predictably within the monorepo structure.
-* **New package creation**: If a new package needs to be created, please follow the standards used by the existing packages, including the standard commands `build:dev`, `build:prod`, `test`, `e2e-test`, `lint`
+- **TypeScript**: Always use strict typing. Avoid `any`.
+- **Linting & Formatting**: Follow the existing code style and formatting conventions used in the files you are editing. If the package you are changing defines linting or formatting scripts, run those before submitting code.
+- **Testing**: Ensure that logic changes are covered by tests, and run the relevant test commands for the packages you modify (see their documentation or `package.json`).
+- **Component Design**: Follow functional component patterns and ensure that UI state is managed predictably within the monorepo structure.
+- **New package creation**: If a new package needs to be created, please follow the standards used by the existing packages, including the standard commands `build:dev`, `build:prod`, `test`, `e2e-test`, `lint`
+
+## LLM Usage Policy
+
+In this project, we welcome tools that help developers become more productive — including Large Language Models (LLMs) and Agents like ChatGPT, GitHub Copilot, and others.
+
+To ensure a healthy and productive community, the following expectations apply:
+
+### Acceptable Use of LLMs
+
+- LLMs may be used to **assist your development** — e.g. drafting code, writing documentation, proposing fixes — as long as **you understand, validate**, and **take responsibility for the results.**
+- You should only submit contributions (PRs, comments, discussions, issues) that reflect your **own understanding** and **intent**, not what an Agent/LLM "spit out."
+- You may use Agents/LLMs to help you **write better**, but not to **post more**.
+
+### Unacceptable Use
+
+- Submitting code, tests, comments, or issues that appear to be **copied directly from an LLM with little or no human oversight** is **not acceptable**.
+- Posting **large volumes of low-effort suggestions, vague issues, or links with no context** — even if technically accurate — is considered spam.
+- Submitting **AI-generated tests that do not validate actual behavior** or meaningfully cover functionality is not helpful and will be rejected.
+- Using bots, agents, or automated tools to open PRs, file issues, or post content **without human authorship and responsibility** is not allowed.
+
+### Consequences
+
+- We may close issues, PRs, or discussions that violate this policy without detailed explanation.
+- Repeated violations may result in temporary or permanent restrictions from participating in the project.
+
+### If in Doubt
+
+If you're unsure whether your use of Agents/LLMs is acceptable - ask! We're happy to help contributors learn how to use AI tools effectively **without creating noise**.
+
+> This isn’t about banning AI - it’s about keeping this project collaborative, human-driven, and focused on quality.
 
 ## Pull Request Process
 
@@ -90,4 +123,5 @@ For new features or architectural changes:
 ---
 
 ### Community and Communication
+
 Join the conversation on the [CNCF Slack](https://slack.cncf.io/) in the `#serverless-workflow` channel.


### PR DESCRIPTION
### Summary:

Closes: https://github.com/serverlessworkflow/editor/issues/42

Add an LLM Usage Policy section to CONTRIBUTING.md.

The policy welcomes AI tools as productivity aids while setting clear expectations around human oversight and contribution quality. It outlines what is and isn't acceptable use, and the consequences for violations.

Also make bullets consistent and add some spacing