### PR TITLE
feat: Add model to store

### DIFF
--- a/packages/serverless-workflow-diagram-editor/src/diagram-editor/DiagramEditor.tsx
+++ b/packages/serverless-workflow-diagram-editor/src/diagram-editor/DiagramEditor.tsx
@@ -27,6 +27,7 @@ export type DiagramEditorRef = {
 };
 
 export type DiagramEditorProps = {
+  content: string;
   isReadOnly: boolean;
   locale: string;
   ref?: React.Ref<DiagramEditorRef>;
@@ -63,7 +64,7 @@ export const DiagramEditor = (props: DiagramEditorProps) => {
 
   return (
     <>
-      <DiagramEditorContextProvider isReadOnly={props.isReadOnly} locale={locale}>
+      <DiagramEditorContextProvider content={props.content} isReadOnly={props.isReadOnly} locale={locale}>
         <I18nProvider locale={locale} dictionaries={dictionaries}>
           <Content />
           <Diagram ref={diagramRef} divRef={diagramDivRef} />

--- a/packages/serverless-workflow-diagram-editor/src/store/DiagramEditorContext.tsx
+++ b/packages/serverless-workflow-diagram-editor/src/store/DiagramEditorContext.tsx
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 
+import type { Specification } from "@serverlessworkflow/sdk";
 import * as React from "react";
 
 export type DiagramEditorContextType = {
   isReadOnly: boolean;
   locale: string;
+  model: Specification.Workflow | null;
+  errors: Error[];
 
   updateIsReadOnly: (isReadOnly: boolean) => void;
   updateLocale: (locale: string) => void;

--- a/packages/serverless-workflow-diagram-editor/src/store/DiagramEditorContextProvider.tsx
+++ b/packages/serverless-workflow-diagram-editor/src/store/DiagramEditorContextProvider.tsx
@@ -29,8 +29,7 @@ export const DiagramEditorContextProvider = (
   const [isReadOnly, setIsReadOnly] = React.useState<boolean>(props.isReadOnly);
   const [locale, setLocale] = React.useState<string>(props.locale);
 
-  const [model, setModel] = React.useState<Specification.Workflow | null>(null);
-  const [errors, setErrors] = React.useState<Error[]>([]);
+  const { model, errors } = React.useMemo(() => parseWorkflow(props.content), [props.content]);
 
   const updateIsReadOnly = React.useCallback((isReadOnly: boolean) => {
     setIsReadOnly(isReadOnly);
@@ -45,12 +44,6 @@ export const DiagramEditorContextProvider = (
     updateIsReadOnly(props.isReadOnly);
     updateLocale(props.locale);
   }, [props.isReadOnly, props.locale, updateIsReadOnly, updateLocale]);
-
-  React.useEffect(() => {
-    const result = parseWorkflow(props.content);
-    setModel(result.model);
-    setErrors(result.errors);
-  }, [props.content]);
 
   // Memoize context value to prevent unnecessary re-renders of consumers
   const context = React.useMemo<DiagramEditorContextType>(

--- a/packages/serverless-workflow-diagram-editor/src/store/DiagramEditorContextProvider.tsx
+++ b/packages/serverless-workflow-diagram-editor/src/store/DiagramEditorContextProvider.tsx
@@ -15,6 +15,8 @@
  */
 
 import * as React from "react";
+import type { Specification } from "@serverlessworkflow/sdk";
+import { parseWorkflow } from "../core";
 import { DiagramEditorProps } from "../diagram-editor/DiagramEditor";
 import { DiagramEditorContext, DiagramEditorContextType } from "./DiagramEditorContext";
 
@@ -26,6 +28,9 @@ export const DiagramEditorContextProvider = (
   // Initialize states with props values
   const [isReadOnly, setIsReadOnly] = React.useState<boolean>(props.isReadOnly);
   const [locale, setLocale] = React.useState<string>(props.locale);
+
+  const [model, setModel] = React.useState<Specification.Workflow | null>(null);
+  const [errors, setErrors] = React.useState<Error[]>([]);
 
   const updateIsReadOnly = React.useCallback((isReadOnly: boolean) => {
     setIsReadOnly(isReadOnly);
@@ -41,15 +46,23 @@ export const DiagramEditorContextProvider = (
     updateLocale(props.locale);
   }, [props.isReadOnly, props.locale, updateIsReadOnly, updateLocale]);
 
+  React.useEffect(() => {
+    const result = parseWorkflow(props.content);
+    setModel(result.model);
+    setErrors(result.errors);
+  }, [props.content]);
+
   // Memoize context value to prevent unnecessary re-renders of consumers
   const context = React.useMemo<DiagramEditorContextType>(
     () => ({
       isReadOnly,
       locale,
+      model,
+      errors,
       updateIsReadOnly,
       updateLocale,
     }),
-    [isReadOnly, locale, updateIsReadOnly, updateLocale],
+    [isReadOnly, locale, model, errors, updateIsReadOnly, updateLocale],
   );
 
   return (

--- a/packages/serverless-workflow-diagram-editor/stories/DiagramEditor.stories.ts
+++ b/packages/serverless-workflow-diagram-editor/stories/DiagramEditor.stories.ts
@@ -37,5 +37,6 @@ export const Component: Story = {
   args: {
     isReadOnly: true,
     locale: "en",
+    content: "", // TODO: Replace with a sample workflow YAML once diagram renders from model
   },
 };

--- a/packages/serverless-workflow-diagram-editor/stories/DiagramEditor.tsx
+++ b/packages/serverless-workflow-diagram-editor/stories/DiagramEditor.tsx
@@ -23,7 +23,7 @@ import {
 export const DiagramEditor = ({ ...props }: DiagramEditorProps) => {
   return (
     <div style={{ height: "100vh" }}>
-      <Component isReadOnly={props.isReadOnly} locale={props.locale} />
+      <Component content={props.content} isReadOnly={props.isReadOnly} locale={props.locale} />
     </div>
   );
 };

--- a/packages/serverless-workflow-diagram-editor/tests/diagram-editor/DiagramEditor.story.test.tsx
+++ b/packages/serverless-workflow-diagram-editor/tests/diagram-editor/DiagramEditor.story.test.tsx
@@ -18,6 +18,7 @@ import { render, screen } from "@testing-library/react";
 import { composeStories } from "@storybook/react-vite";
 import * as stories from "../../stories/DiagramEditor.stories";
 import { vi, test, expect, afterEach, describe } from "vitest";
+import { BASIC_VALID_WORKFLOW_YAML } from "../fixtures/workflows";
 
 // Composes all stories in the file
 const { Component } = composeStories(stories);
@@ -31,7 +32,7 @@ describe("Story - DiagramEditor component", () => {
     const locale = "en";
     const isReadOnly = true;
 
-    render(<Component locale={locale} isReadOnly={isReadOnly} />);
+    render(<Component content={BASIC_VALID_WORKFLOW_YAML} locale={locale} isReadOnly={isReadOnly} />);
 
     const reactFlowContainer = screen.getByTestId("diagram-container");
 

--- a/packages/serverless-workflow-diagram-editor/tests/diagram-editor/DiagramEditor.test.tsx
+++ b/packages/serverless-workflow-diagram-editor/tests/diagram-editor/DiagramEditor.test.tsx
@@ -17,6 +17,7 @@
 import { render, screen } from "@testing-library/react";
 import { DiagramEditor } from "../../src/diagram-editor";
 import { vi, test, expect, afterEach, describe } from "vitest";
+import { BASIC_VALID_WORKFLOW_YAML } from "../fixtures/workflows";
 
 describe("DiagramEditor Component", () => {
   afterEach(() => {
@@ -27,7 +28,7 @@ describe("DiagramEditor Component", () => {
     const locale = "en";
     const isReadOnly = true;
 
-    render(<DiagramEditor locale={locale} isReadOnly={isReadOnly} />);
+    render(<DiagramEditor content={BASIC_VALID_WORKFLOW_YAML} locale={locale} isReadOnly={isReadOnly} />);
 
     const reactFlowContainer = screen.getByTestId("diagram-container");
 

--- a/packages/serverless-workflow-diagram-editor/tests/store/DiagramEditorContextProvider.test.tsx
+++ b/packages/serverless-workflow-diagram-editor/tests/store/DiagramEditorContextProvider.test.tsx
@@ -15,13 +15,14 @@
  */
 
 import * as React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { vi, expect, afterEach, describe, it } from "vitest";
 import { useDiagramEditorContext } from "../../src/store/DiagramEditorContext";
 import { DiagramEditorContextProvider } from "../../src/store/DiagramEditorContextProvider";
+import { BASIC_INVALID_WORKFLOW_YAML, BASIC_VALID_WORKFLOW_YAML } from "../fixtures/workflows";
 
 const TestComponent: React.FC = () => {
-  const { isReadOnly, locale } = useDiagramEditorContext();
+  const { isReadOnly, locale, model, errors } = useDiagramEditorContext();
   const renderCount = React.useRef<number>(0);
 
   // Increments on every render cycle
@@ -31,6 +32,8 @@ const TestComponent: React.FC = () => {
     <div data-testid="test-wrapper">
       <p data-testid="test-read-only">{`${isReadOnly}`}</p>
       <p data-testid="test-locale">{`${locale}`}</p>
+      <p data-testid="test-model">{`${model ? model.document?.name : "null"}`}</p>
+      <p data-testid="test-errors">{`${errors.length}`}</p>
       <p data-testid="test-render">{`${renderCount.current}`}</p>
     </div>
   );
@@ -43,7 +46,11 @@ describe("DiagramEditorContextProvider Component", () => {
 
   it("Consume properties from context", async () => {
     render(
-      <DiagramEditorContextProvider isReadOnly={true} locale={"en"}>
+      <DiagramEditorContextProvider
+        content={BASIC_VALID_WORKFLOW_YAML}
+        isReadOnly={true}
+        locale={"en"}
+      >
         <TestComponent />
       </DiagramEditorContextProvider>,
     );
@@ -55,19 +62,27 @@ describe("DiagramEditorContextProvider Component", () => {
     expect(readOnlyElement).toHaveTextContent(/true/i);
     expect(readOnlyLocale).toHaveTextContent(/en/i);
 
-    // Only one rendering cycle is expected
-    expect(renderCount).toHaveTextContent(/1/i);
+    // 2 rendering cycles are expected: 1- first render, 2- content useEffect triggers state update
+    expect(renderCount).toHaveTextContent(/2/i);
   });
 
   it("Context provider props changes shall cause internal component to reload", async () => {
     const { rerender } = render(
-      <DiagramEditorContextProvider isReadOnly={true} locale={"en"}>
+      <DiagramEditorContextProvider
+        content={BASIC_VALID_WORKFLOW_YAML}
+        isReadOnly={true}
+        locale={"en"}
+      >
         <TestComponent />
       </DiagramEditorContextProvider>,
     );
 
     rerender(
-      <DiagramEditorContextProvider isReadOnly={false} locale={"pt"}>
+      <DiagramEditorContextProvider
+        content={BASIC_VALID_WORKFLOW_YAML}
+        isReadOnly={false}
+        locale={"pt"}
+      >
         <TestComponent />
       </DiagramEditorContextProvider>,
     );
@@ -79,19 +94,27 @@ describe("DiagramEditorContextProvider Component", () => {
     expect(readOnlyElementChanged).toHaveTextContent(/false/i);
     expect(readOnlyLocaleChanged).toHaveTextContent(/pt/i);
 
-    // 3 rendering cycles are expected 1- first render, 2- forced by rerender and 3- caused by state updates
-    expect(renderCount).toHaveTextContent(/3/i);
+    // 4 rendering cycles are expected 1- first render, 2- content useEffect triggers state update, 3- forced by rerender and 4- isReadOnly/locale useeffect state update
+    expect(renderCount).toHaveTextContent(/4/i);
   });
 
   it("Context provider same props shall not cause internal component to reload", async () => {
     const { rerender } = render(
-      <DiagramEditorContextProvider isReadOnly={true} locale={"en"}>
+      <DiagramEditorContextProvider
+        content={BASIC_VALID_WORKFLOW_YAML}
+        isReadOnly={true}
+        locale={"en"}
+      >
         <TestComponent />
       </DiagramEditorContextProvider>,
     );
 
     rerender(
-      <DiagramEditorContextProvider isReadOnly={true} locale={"en"}>
+      <DiagramEditorContextProvider
+        content={BASIC_VALID_WORKFLOW_YAML}
+        isReadOnly={true}
+        locale={"en"}
+      >
         <TestComponent />
       </DiagramEditorContextProvider>,
     );
@@ -103,7 +126,96 @@ describe("DiagramEditorContextProvider Component", () => {
     expect(readOnlyElementChanged).toHaveTextContent(/true/i);
     expect(readOnlyLocaleChanged).toHaveTextContent(/en/i);
 
-    // 2 rendering cycles are expected 1- first render and 2- forced by rerender
-    expect(renderCount).toHaveTextContent(/2/i);
+    // 3 rendering cycles are expected 1- first render, 2- content useEffect triggers state update and 3- forced by rerender
+    expect(renderCount).toHaveTextContent(/3/i);
+  });
+
+  it("Parses valid workflow content into model with no errors", async () => {
+    render(
+      <DiagramEditorContextProvider
+        content={BASIC_VALID_WORKFLOW_YAML}
+        isReadOnly={true}
+        locale={"en"}
+      >
+        <TestComponent />
+      </DiagramEditorContextProvider>,
+    );
+
+    const modelElement = await screen.findByTestId("test-model");
+    const errorsElement = screen.getByTestId("test-errors");
+
+    await waitFor(() => {
+      expect(modelElement).toHaveTextContent("valid-workflow-yaml");
+      expect(errorsElement).toHaveTextContent("0");
+    });
+  });
+
+  it("Parses invalid workflow content into model with errors", async () => {
+    render(
+      <DiagramEditorContextProvider
+        content={BASIC_INVALID_WORKFLOW_YAML}
+        isReadOnly={true}
+        locale={"en"}
+      >
+        <TestComponent />
+      </DiagramEditorContextProvider>,
+    );
+
+    const modelElement = screen.getByTestId("test-model");
+    const errorsElement = screen.getByTestId("test-errors");
+
+    await waitFor(() => {
+      // Model is still returned as parsing succeeded but has validation errors
+      expect(modelElement).toBeInTheDocument();
+      expect(errorsElement).toHaveTextContent("1");
+    })
+  });
+
+  it("Parses empty workflow content into null model with errors", async () => {
+    render(
+      <DiagramEditorContextProvider content={""} isReadOnly={true} locale={"en"}>
+        <TestComponent />
+      </DiagramEditorContextProvider>,
+    );
+
+    const modelElement = screen.getByTestId("test-model");
+    const errorsElement = screen.getByTestId("test-errors");
+
+    await waitFor(() => {
+      // Model is null as parsing failed and errors are returned
+      expect(modelElement).toHaveTextContent("null");
+      expect(errorsElement).toHaveTextContent("1");
+    })
+  });
+
+  it("Updates model when content prop changes", async () => {
+    const { rerender } = render(
+      <DiagramEditorContextProvider
+        content={BASIC_VALID_WORKFLOW_YAML}
+        isReadOnly={true}
+        locale={"en"}
+      >
+        <TestComponent />
+      </DiagramEditorContextProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("test-model")).toHaveTextContent("valid-workflow-yaml");
+      expect(screen.getByTestId("test-errors")).toHaveTextContent("0");
+    });
+
+    rerender(
+      <DiagramEditorContextProvider
+        content={BASIC_INVALID_WORKFLOW_YAML}
+        isReadOnly={true}
+        locale={"en"}
+      >
+        <TestComponent />
+      </DiagramEditorContextProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("test-errors")).toHaveTextContent("1");
+    })
   });
 });

--- a/packages/serverless-workflow-diagram-editor/tests/store/DiagramEditorContextProvider.test.tsx
+++ b/packages/serverless-workflow-diagram-editor/tests/store/DiagramEditorContextProvider.test.tsx
@@ -62,8 +62,8 @@ describe("DiagramEditorContextProvider Component", () => {
     expect(readOnlyElement).toHaveTextContent(/true/i);
     expect(readOnlyLocale).toHaveTextContent(/en/i);
 
-    // 2 rendering cycles are expected: 1- first render, 2- content useEffect triggers state update
-    expect(renderCount).toHaveTextContent(/2/i);
+    // Only one rendering cycle is expected
+    expect(renderCount).toHaveTextContent(/1/i);
   });
 
   it("Context provider props changes shall cause internal component to reload", async () => {
@@ -94,8 +94,8 @@ describe("DiagramEditorContextProvider Component", () => {
     expect(readOnlyElementChanged).toHaveTextContent(/false/i);
     expect(readOnlyLocaleChanged).toHaveTextContent(/pt/i);
 
-    // 4 rendering cycles are expected 1- first render, 2- content useEffect triggers state update, 3- forced by rerender and 4- isReadOnly/locale useeffect state update
-    expect(renderCount).toHaveTextContent(/4/i);
+    // 3 rendering cycles are expected 1- first render, 2- forced by rerender and 3- caused by state updates
+    expect(renderCount).toHaveTextContent(/3/i);
   });
 
   it("Context provider same props shall not cause internal component to reload", async () => {
@@ -126,8 +126,8 @@ describe("DiagramEditorContextProvider Component", () => {
     expect(readOnlyElementChanged).toHaveTextContent(/true/i);
     expect(readOnlyLocaleChanged).toHaveTextContent(/en/i);
 
-    // 3 rendering cycles are expected 1- first render, 2- content useEffect triggers state update and 3- forced by rerender
-    expect(renderCount).toHaveTextContent(/3/i);
+    // 2 rendering cycles are expected 1- first render and 2- forced by rerender
+    expect(renderCount).toHaveTextContent(/2/i);
   });
 
   it("Parses valid workflow content into model with no errors", async () => {
@@ -168,7 +168,7 @@ describe("DiagramEditorContextProvider Component", () => {
       // Model is still returned as parsing succeeded but has validation errors
       expect(modelElement).toBeInTheDocument();
       expect(errorsElement).toHaveTextContent("1");
-    })
+    });
   });
 
   it("Parses empty workflow content into null model with errors", async () => {
@@ -185,7 +185,7 @@ describe("DiagramEditorContextProvider Component", () => {
       // Model is null as parsing failed and errors are returned
       expect(modelElement).toHaveTextContent("null");
       expect(errorsElement).toHaveTextContent("1");
-    })
+    });
   });
 
   it("Updates model when content prop changes", async () => {
@@ -216,6 +216,6 @@ describe("DiagramEditorContextProvider Component", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("test-errors")).toHaveTextContent("1");
-    })
+    });
   });
 });


### PR DESCRIPTION
Closes: https://github.com/serverlessworkflow/editor/issues/49

## Summary

Adds parsed workflow model and validation errors to the `DiagramEditor` store, establishing a single source of truth for workflow data accessible throughout the component 

Files Modified                                                                                                                                                                 
 - src/diagram-editor/DiagramEditor.tsx - Added content prop                                                                                                                   
- src/store/DiagramEditorContext.tsx - Added model and errors to context type                                                                                                 
- src/store/DiagramEditorContextProvider.tsx - Implemented parsing logic and state management                                                                                
- stories/DiagramEditor.stories.ts - Updated with content prop (TODO: add sample workflow)                                                                                    
- stories/DiagramEditor.tsx - Passed content prop through