### PR TITLE
Add libraries, config and style error page

### DIFF
--- a/packages/serverless-workflow-diagram-editor/.storybook/preview.ts
+++ b/packages/serverless-workflow-diagram-editor/.storybook/preview.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import "../src/styles.css";
 import type { Preview } from "@storybook/react-vite";
 
 const preview: Preview = {

--- a/packages/serverless-workflow-diagram-editor/package.json
+++ b/packages/serverless-workflow-diagram-editor/package.json
@@ -22,7 +22,8 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
-    }
+    },
+    "./styles.css": "./dist/styles.css"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
@@ -52,6 +53,7 @@
     "@storybook/addon-docs": "catalog:",
     "@storybook/addon-vitest": "catalog:",
     "@storybook/react-vite": "catalog:",
+    "@tailwindcss/vite": "catalog:",
     "@testing-library/dom": "catalog:",
     "@testing-library/jest-dom": "catalog:",
     "@testing-library/react": "catalog:",
@@ -63,12 +65,14 @@
     "@vitest/coverage-v8": "catalog:",
     "@vitest/ui": "catalog:",
     "jsdom": "catalog:",
+    "lucide-react": "catalog:",
     "oxfmt": "catalog:",
     "oxlint": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
     "rimraf": "catalog:",
     "storybook": "catalog:",
+    "tailwindcss": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/serverless-workflow-diagram-editor/src/diagram-editor/DiagramEditor.tsx
+++ b/packages/serverless-workflow-diagram-editor/src/diagram-editor/DiagramEditor.tsx
@@ -21,8 +21,8 @@ import { I18nProvider, detectLocale } from "@serverlessworkflow/i18n";
 import { dictionaries } from "../i18n/locales";
 import { useDiagramEditorContext } from "../store/DiagramEditorContext";
 import { ParsingErrorPage } from "./error-pages/ParsingErrorPage";
-import "./DiagramEditor.css";
-import { ColorMode } from "../types/colorMode";
+import { ColorMode, ResolvedColorMode } from "../types/colorMode";
+import { useResolvedColorMode } from "../hooks/useResolvedColorMode";
 
 /**
  * DiagramEditor component API
@@ -46,7 +46,7 @@ const DiagramEditorContent = ({
 }: {
   diagramRef: React.RefObject<DiagramRef | null>;
   diagramDivRef: React.RefObject<HTMLDivElement | null>;
-  colorMode: ColorMode;
+  colorMode: ResolvedColorMode;
 }) => {
   const { model } = useDiagramEditorContext();
   return model === null ? (
@@ -67,6 +67,7 @@ export const DiagramEditor = (props: DiagramEditorProps) => {
     return props.locale ?? detectLocale(supportedLocales);
   }, [props.locale]);
   const colorMode: ColorMode = props.colorMode ?? "system";
+  const resolvedColorMode = useResolvedColorMode(colorMode);
 
   // Allow imperatively controlling the Editor
   React.useImperativeHandle(
@@ -80,7 +81,10 @@ export const DiagramEditor = (props: DiagramEditorProps) => {
   );
 
   return (
-    <>
+    <div
+      className={`dec-root${resolvedColorMode === "dark" ? " dark" : ""}`}
+      data-testid={"dec-root"}
+    >
       <DiagramEditorContextProvider
         content={props.content}
         isReadOnly={props.isReadOnly}
@@ -90,10 +94,10 @@ export const DiagramEditor = (props: DiagramEditorProps) => {
           <DiagramEditorContent
             diagramRef={diagramRef}
             diagramDivRef={diagramDivRef}
-            colorMode={colorMode}
+            colorMode={resolvedColorMode}
           />
         </I18nProvider>
       </DiagramEditorContextProvider>
-    </>
+    </div>
   );
 };

--- a/packages/serverless-workflow-diagram-editor/src/diagram-editor/error-pages/ErrorPage.tsx
+++ b/packages/serverless-workflow-diagram-editor/src/diagram-editor/error-pages/ErrorPage.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { AlertTriangle } from "lucide-react";
 
 type ErrorPageProps = {
   title: string;
@@ -21,13 +22,19 @@ type ErrorPageProps = {
 };
 
 export const ErrorPage = ({ title, message, snippet }: ErrorPageProps) => {
-  // TODO: Apply styling later
   return (
-    <div style={{ padding: "1rem" }}>
-      <h2>{title}</h2>
-      {message ? <p>{message}</p> : null}
+    <div className="dec:p-6">
+      <div className="dec:flex dec:items-center dec:gap-2">
+        <AlertTriangle className="dec:size-5 dec:shrink-0 dec:text-red-600 dec:dark:text-red-400" />
+        <h2 className="dec:text-base dec:font-semibold dec:text-gray-900 dec:dark:text-gray-100">
+          {title}
+        </h2>
+      </div>
+      {message ? (
+        <p className="dec:mt-1 dec:text-sm dec:text-gray-600 dec:dark:text-gray-100">{message}</p>
+      ) : null}
       {snippet ? (
-        <pre>
+        <pre className="dec:mt-3 dec:p-3 dec:overflow-x-auto dec:rounded dec:bg-gray-100 dec:text-sm dec:text-gray-800 dec:dark:bg-gray-800 dec:dark:text-gray-200">
           <code>{snippet}</code>
         </pre>
       ) : null}

--- a/packages/serverless-workflow-diagram-editor/src/hooks/useResolvedColorMode.ts
+++ b/packages/serverless-workflow-diagram-editor/src/hooks/useResolvedColorMode.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useState } from "react";
+import { ColorMode, ResolvedColorMode } from "../types/colorMode";
+
+const DARK_MEDIA_QUERY = "(prefers-color-scheme: dark)";
+
+function getSystemColorMode(): ResolvedColorMode {
+  if (typeof window !== "undefined" && typeof window.matchMedia === "function") {
+    return window.matchMedia(DARK_MEDIA_QUERY).matches ? "dark" : "light";
+  }
+  return "light"; // Default to light
+}
+
+export function useResolvedColorMode(colorMode: ColorMode): ResolvedColorMode {
+  const [resolvedColorMode, setResolvedColorMode] = useState<ResolvedColorMode>(
+    colorMode === "system" ? getSystemColorMode() : colorMode,
+  );
+
+  useEffect(() => {
+    if (colorMode !== "system") {
+      setResolvedColorMode(colorMode);
+      return;
+    }
+
+    setResolvedColorMode(getSystemColorMode());
+
+    const mediaQuery = window.matchMedia(DARK_MEDIA_QUERY);
+    const handler = (e: MediaQueryListEvent) => {
+      setResolvedColorMode(e.matches ? "dark" : "light");
+    };
+    mediaQuery.addEventListener("change", handler);
+
+    return () => {
+      mediaQuery.removeEventListener("change", handler);
+    };
+  }, [colorMode]);
+
+  return resolvedColorMode;
+}

--- a/packages/serverless-workflow-diagram-editor/src/index.ts
+++ b/packages/serverless-workflow-diagram-editor/src/index.ts
@@ -14,5 +14,6 @@
  * limitations under the License.
  */
 
+import "./styles.css";
 export * from "./diagram-editor";
 export * from "./types/colorMode";

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.css
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.css
@@ -14,53 +14,12 @@
  * limitations under the License.
  */
 
-.diagram-container {
-  height: 100%;
-  position: relative;
-}
-
-.diagram-container .diagram-background {
+.diagram-background {
   --xy-background-pattern-color: #ccc;
   background-color: #e5e4e2;
 }
 
-.dark .diagram-container .diagram-background{ 
+.dark .diagram-background{ 
     --xy-background-pattern-color: inherit;
     background-color: inherit;
-}
-
-@media (prefers-color-scheme: dark) {
-    .diagram-container.colorMode-system .diagram-background{ 
-        --xy-background-pattern-color: inherit;
-        background-color: inherit;
-    }
-}
-
-/* React flow Nodes */
-
-.node-label-container {
-    white-space: pre;
-    padding: 7px; 
-}
-
-.custom-node-container {
-    border-radius: 5px;
-    background: white;
-    border: 1px solid #000;
-    transition: border ease, box-shadow ease;
-    height: calc(100% - 2px); /* compensate for the border */
-    width: calc(100% - 2px); /* compensate for the border */
-}
-
-.custom-node-container:hover {
-    border: 1px solid #000;
-    box-shadow: 0 0 10px rgba(0, 65, 208, 0.3);
-    height: calc(100% - 2px); /* compensate for the border */
-    width: calc(100% - 2px); /* compensate for the border */
-}
-
-.custom-node-container.selected {
-    background: #aebbd5;
-    border: 1px solid #000;
-    box-shadow: 0 0 10px rgba(1, 79, 248, 0.3);
 }

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.css
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.css
@@ -24,7 +24,7 @@
   background-color: #e5e4e2;
 }
 
-.diagram-container.colorMode-dark .diagram-background{ 
+.dark .diagram-container .diagram-background{ 
     --xy-background-pattern-color: inherit;
     background-color: inherit;
 }

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.tsx
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.tsx
@@ -22,6 +22,7 @@ import { DEFAULT_NODE_SIZE } from "../../core";
 import { ColorMode } from "../../types/colorMode";
 import "@xyflow/react/dist/style.css";
 import "./Diagram.css";
+import { ResolvedColorMode } from "../../types/colorMode";
 
 const FIT_VIEW_OPTIONS: RF.FitViewOptions = {
   maxZoom: 1,
@@ -155,10 +156,10 @@ export type DiagramRef = {
 export type DiagramProps = {
   divRef?: React.RefObject<HTMLDivElement | null>;
   ref?: React.Ref<DiagramRef>;
-  colorMode?: ColorMode;
+  colorMode?: ResolvedColorMode;
 };
 
-export const Diagram = ({ divRef, ref, colorMode = "system" }: DiagramProps) => {
+export const Diagram = ({ divRef, ref, colorMode = "light" }: DiagramProps) => {
   const [minimapVisible, setMinimapVisible] = React.useState(false);
   const [nodes, setNodes] = React.useState<RF.Node[]>(initialNodes);
   const [edges, setEdges] = React.useState<RF.Edge[]>(initialEdges);
@@ -183,7 +184,7 @@ export const Diagram = ({ divRef, ref, colorMode = "system" }: DiagramProps) => 
   );
 
   return (
-    <div ref={divRef} className={`diagram-container colorMode-${colorMode}`} data-testid={"diagram-container"}>
+    <div ref={divRef} className="diagram-container" data-testid={"diagram-container"}>
       <RF.ReactFlow
         nodeTypes={NodeTypes}
         nodes={nodes}

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.tsx
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.tsx
@@ -19,7 +19,6 @@ import * as RF from "@xyflow/react";
 import { GraphNodeType } from "@serverlessworkflow/sdk";
 import { NodeTypes } from "../nodes/Nodes";
 import { DEFAULT_NODE_SIZE } from "../../core";
-import { ColorMode } from "../../types/colorMode";
 import "@xyflow/react/dist/style.css";
 import "./Diagram.css";
 import { ResolvedColorMode } from "../../types/colorMode";
@@ -184,7 +183,7 @@ export const Diagram = ({ divRef, ref, colorMode = "light" }: DiagramProps) => {
   );
 
   return (
-    <div ref={divRef} className="diagram-container" data-testid={"diagram-container"}>
+    <div ref={divRef} className="dec:h-full dec:relative" data-testid={"diagram-container"}>
       <RF.ReactFlow
         nodeTypes={NodeTypes}
         nodes={nodes}

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/nodes/Nodes.tsx
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/nodes/Nodes.tsx
@@ -50,11 +50,11 @@ interface PlaceholderProps {
 function PlaceholderContent({ id, data, selected, type }: PlaceholderProps) {
   return (
     <div
-      className={`custom-node-container ${selected ? "selected" : ""}`}
-      data-testid={`${type}-node-${id}`}
+      className={`dec:rounded dec:border dec:border-gray-300 dec:dark:border-gray-600 dec:bg-white dec:dark:bg-gray-800  dec:text-gray-900 dec:dark:text-gray-100${selected ?' dec:ring-2 dec:ring-blue-400' : ""}`}
+       data-testid={`${type}-node-${id}`}
     >
       <RF.Handle type="target" position={RF.Position.Top} />
-      <div className="node-label-container" data-testid={`${type}-label-${id}`}>
+      <div className="dec:whitespace-pre dec:p-[7px]" data-testid={`${type}-label-${id}`}>
         {`${type}\n${data.label}`}
       </div>
       <RF.Handle type="source" position={RF.Position.Bottom} />

--- a/packages/serverless-workflow-diagram-editor/src/styles.css
+++ b/packages/serverless-workflow-diagram-editor/src/styles.css
@@ -14,22 +14,23 @@
  * limitations under the License.
  */
 
- /* The css to be updated after tailwind update */
-.headingContent {
-  color: #000000;
-  background-color: #F8F8F8;
-  margin: 0;
-  padding: 1%;
-}
+@import "tailwindcss" prefix(dec);
 
-.headingContent.colorMode-dark {
-    color: #F8F8F8;
-    background-color: #141414;
-}
+@custom-variant dark (&:where(.dec-root.dark, .dec-root.dark *));
 
-@media (prefers-color-scheme: dark) {
-    .headingContent.colorMode-system {
-        color: #F8F8F8;
-        background-color: #141414;
-    }
+/*
+  This file defines global styles for the editor.
+
+  Any global selectors must be carefully scoped within `.dec-root`
+  to avoid leaking into the host application.
+
+  Prefer component-level or locally scoped styles elsewhere.
+  Do not introduce unscoped global styles, as the editor is designed
+  to be embedded within other applications.
+
+  Tailwind utilities are prefixed with `dec:` (Diagram Editor Component)
+  to reduce the risk of conflicts with host application styles.
+*/
+.dec-root {
+  height: 100%;
 }

--- a/packages/serverless-workflow-diagram-editor/src/types/colorMode.ts
+++ b/packages/serverless-workflow-diagram-editor/src/types/colorMode.ts
@@ -15,3 +15,4 @@
  */
 
 export type ColorMode = "light" | "dark" | "system";
+export type ResolvedColorMode = "light" | "dark";

--- a/packages/serverless-workflow-diagram-editor/stories/ErrorPage.stories.tsx
+++ b/packages/serverless-workflow-diagram-editor/stories/ErrorPage.stories.tsx
@@ -16,6 +16,32 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { ErrorPage } from "../src/diagram-editor/error-pages/ErrorPage";
+import { PropsWithChildren } from "react";
+import { ColorMode } from "../src/types/colorMode";
+import { useResolvedColorMode } from "../src/hooks/useResolvedColorMode";
+
+type ErrorPageProps = {
+  title: string;
+  message?: string | undefined;
+  snippet?: string | undefined;
+};
+
+type ErrorPageStoryProps = ErrorPageProps & {
+  colorMode?: ColorMode;
+};
+
+/* Simulates the "dec-root" wrapper of the DiagramEditor so we can toggle light/dark/system color modes independently. */
+const DecRoot = ({ colorMode, children }: PropsWithChildren<{ colorMode: ColorMode }>) => {
+  const resolved = useResolvedColorMode(colorMode);
+  return (
+    <div
+      className={`dec-root${resolved === "dark" ? " dark" : ""}`}
+      style={{ backgroundColor: resolved === "dark" ? "#1a1a1a" : "#fff", minHeight: "100vh" }}
+    >
+      {children}
+    </div>
+  );
+};
 
 const meta = {
   title: "Example/ErrorPage",
@@ -26,11 +52,31 @@ const meta = {
     // More on how to position stories at: https://storybook.js.org/docs/configure/story-layout
     layout: "fullscreen",
   },
-  args: {},
-} satisfies Meta<typeof ErrorPage>;
+  argTypes: {
+    colorMode: {
+      control: { type: "select" },
+      options: ["light", "dark", "system"],
+      description:
+        "The color mode to use for the error page. 'system' will use the user's system preference.",
+    },
+  },
+  args: {
+    colorMode: "system",
+  },
+  decorators: [
+    (Story, context) => {
+      const { colorMode, ...storyArgs } = context.args;
+      return (
+        <DecRoot colorMode={colorMode ?? "system"}>
+          <Story args={storyArgs} />
+        </DecRoot>
+      );
+    },
+  ],
+} satisfies Meta<ErrorPageStoryProps>;
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<ErrorPageStoryProps>;
 
 export const TitleOnly: Story = {
   args: {

--- a/packages/serverless-workflow-diagram-editor/tests/diagram-editor/DiagramEditor.story.test.tsx
+++ b/packages/serverless-workflow-diagram-editor/tests/diagram-editor/DiagramEditor.story.test.tsx
@@ -41,54 +41,29 @@ describe("Story - DiagramEditor component", () => {
     expect(reactFlowContainer).toBeInTheDocument();
   });
 
-  it("applies light mode class", () => {
-    render(
-      <Component
-        content={BASIC_VALID_WORKFLOW_YAML}
-        locale={locale}
-        isReadOnly={isReadOnly}
-        colorMode="light"
-      />,
-    );
+  it.each([
+    { colorMode: "light" as const, expectedDark: false },
+    { colorMode: "dark" as const, expectedDark: true },
+    { colorMode: "system" as const, expectedDark: false },
+    { colorMode: undefined, expectedDark: false },
+  ])(
+    "applies correct class when colorMode is set to $colorMode",
+    ({ colorMode, expectedDark }) => {
+      render(
+        <Component
+          content={BASIC_VALID_WORKFLOW_YAML}
+          locale={locale}
+          isReadOnly={isReadOnly}
+          colorMode={colorMode}
+        />,
+      );
 
-    const reactFlowContainer = screen.getByTestId("diagram-container");
-    expect(reactFlowContainer).toHaveClass("colorMode-light");
-  });
-
-  it("applies dark mode class", () => {
-    render(
-      <Component
-        content={BASIC_VALID_WORKFLOW_YAML}
-        locale={locale}
-        isReadOnly={isReadOnly}
-        colorMode="dark"
-      />,
-    );
-
-    const reactFlowContainer = screen.getByTestId("diagram-container");
-    expect(reactFlowContainer).toHaveClass("colorMode-dark");
-  });
-
-  it("applies system mode class", () => {
-    render(
-      <Component
-        content={BASIC_VALID_WORKFLOW_YAML}
-        locale={locale}
-        isReadOnly={isReadOnly}
-        colorMode="system"
-      />,
-    );
-
-    const reactFlowContainer = screen.getByTestId("diagram-container");
-    expect(reactFlowContainer).toHaveClass("colorMode-system");
-  });
-
-  it("defaults to system mode when no colorMode is provided", () => {
-    render(
-      <Component content={BASIC_VALID_WORKFLOW_YAML} locale={locale} isReadOnly={isReadOnly} />,
-    );
-
-    const reactFlowContainer = screen.getByTestId("diagram-container");
-    expect(reactFlowContainer).toHaveClass("colorMode-system");
-  });
+      const decRoot = screen.getByTestId("dec-root");
+      if (expectedDark) {
+        expect(decRoot).toHaveClass("dark");
+      } else {
+        expect(decRoot).not.toHaveClass("dark");
+      }
+    },
+  );
 });

--- a/packages/serverless-workflow-diagram-editor/tests/diagram-editor/DiagramEditor.test.tsx
+++ b/packages/serverless-workflow-diagram-editor/tests/diagram-editor/DiagramEditor.test.tsx
@@ -37,54 +37,29 @@ describe("DiagramEditor Component", () => {
     expect(reactFlowContainer).toBeInTheDocument();
   });
 
-  it("applies light mode class", () => {
-    render(
-      <DiagramEditor
-        content={BASIC_VALID_WORKFLOW_YAML}
-        locale={locale}
-        isReadOnly={isReadOnly}
-        colorMode="light"
-      />,
-    );
+  it.each([
+    { colorMode: "light" as const, expectedDark: false },
+    { colorMode: "dark" as const, expectedDark: true },
+    { colorMode: "system" as const, expectedDark: false },
+    { colorMode: undefined, expectedDark: false },
+  ])(
+    "applies correct class when colorMode is set to $colorMode",
+    ({ colorMode, expectedDark }) => {
+      render(
+        <DiagramEditor
+          content={BASIC_VALID_WORKFLOW_YAML}
+          locale={locale}
+          isReadOnly={isReadOnly}
+          colorMode={colorMode}
+        />,
+      );
 
-    const reactFlowContainer = screen.getByTestId("diagram-container");
-    expect(reactFlowContainer).toHaveClass("colorMode-light");
-  });
-
-  it("applies dark mode class", () => {
-    render(
-      <DiagramEditor
-        content={BASIC_VALID_WORKFLOW_YAML}
-        locale={locale}
-        isReadOnly={isReadOnly}
-        colorMode="dark"
-      />,
-    );
-
-    const reactFlowContainer = screen.getByTestId("diagram-container");
-    expect(reactFlowContainer).toHaveClass("colorMode-dark");
-  });
-
-  it("applies system mode class", () => {
-    render(
-      <DiagramEditor
-        content={BASIC_VALID_WORKFLOW_YAML}
-        locale={locale}
-        isReadOnly={isReadOnly}
-        colorMode="system"
-      />,
-    );
-
-    const reactFlowContainer = screen.getByTestId("diagram-container");
-    expect(reactFlowContainer).toHaveClass("colorMode-system");
-  });
-
-  it("defaults to system mode when no colorMode is provided", () => {
-    render(
-      <DiagramEditor content={BASIC_VALID_WORKFLOW_YAML} locale={locale} isReadOnly={isReadOnly} />,
-    );
-
-    const reactFlowContainer = screen.getByTestId("diagram-container");
-    expect(reactFlowContainer).toHaveClass("colorMode-system");
-  });
+      const decRoot = screen.getByTestId("dec-root");
+      if (expectedDark) {
+        expect(decRoot).toHaveClass("dark");
+      } else {
+        expect(decRoot).not.toHaveClass("dark");
+      }
+    },
+  );
 });

--- a/packages/serverless-workflow-diagram-editor/tests/hooks/useResolvedColorMode.test.ts
+++ b/packages/serverless-workflow-diagram-editor/tests/hooks/useResolvedColorMode.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2021-Present The Serverless Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useResolvedColorMode } from "../../src/hooks/useResolvedColorMode";
+import { act, renderHook } from "@testing-library/react";
+
+describe("useResolvedColorMode", () => {
+  let listeners: Array<(e: MediaQueryListEvent) => void> = [];
+  let matchesDark: boolean = false;
+
+  beforeEach(() => {
+    listeners = [];
+    matchesDark = false;
+
+    vi.mocked(window.matchMedia).mockImplementation(
+      (query: string) =>
+        ({
+          matches: query === "(prefers-color-scheme: dark)" ? matchesDark : false,
+          media: query,
+          addEventListener: (event: string, handler: (e: MediaQueryListEvent) => void) => {
+            listeners.push(handler);
+          },
+          removeEventListener: (event: string, handler: (e: MediaQueryListEvent) => void) => {
+            listeners = listeners.filter((h) => h !== handler);
+          },
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        }) as MediaQueryList,
+    );
+  });
+
+  it('returns "light" when colorMode is "light"', () => {
+    const { result } = renderHook(() => useResolvedColorMode("light"));
+    expect(result.current).toBe("light");
+  });
+
+  it('returns "dark" when colorMode is "dark"', () => {
+    const { result } = renderHook(() => useResolvedColorMode("dark"));
+    expect(result.current).toBe("dark");
+  });
+
+  it('resolves "system" to "light" when system is in light mode', () => {
+    matchesDark = false;
+    const { result } = renderHook(() => useResolvedColorMode("system"));
+    expect(result.current).toBe("light");
+  });
+
+  it('resolves "system" to "dark" when system is in dark mode', () => {
+    matchesDark = true;
+    const { result } = renderHook(() => useResolvedColorMode("system"));
+    expect(result.current).toBe("dark");
+  });
+
+  it('reacts to system color scheme changes when colorMode is "system"', () => {
+    matchesDark = false;
+    const { result } = renderHook(() => useResolvedColorMode("system"));
+    expect(result.current).toBe("light");
+
+    act(() => {
+      for (const listener of listeners) {
+        listener({ matches: true } as MediaQueryListEvent);
+      }
+    });
+    expect(result.current).toBe("dark");
+  });
+
+  it("cleans up media query listener on unmount", () => {
+    matchesDark = false;
+    const { unmount } = renderHook(() => useResolvedColorMode("system"));
+    expect(listeners.length).toBe(1);
+    unmount();
+    expect(listeners.length).toBe(0);
+  });
+});

--- a/packages/serverless-workflow-diagram-editor/tests/setupTests.ts
+++ b/packages/serverless-workflow-diagram-editor/tests/setupTests.ts
@@ -32,3 +32,18 @@ vi.stubGlobal(
     disconnect() {}
   },
 );
+
+// Mock matchMedia
+vi.stubGlobal(
+  "matchMedia",
+  vi.fn((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+);

--- a/packages/serverless-workflow-diagram-editor/vite.config.ts
+++ b/packages/serverless-workflow-diagram-editor/vite.config.ts
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
 
 export default defineConfig({
+  plugins: [tailwindcss()],
   resolve: {
     tsconfigPaths: true,
   },
@@ -26,6 +27,7 @@ export default defineConfig({
     lib: {
       entry: "src/index.ts",
       fileName: (format) => (format === "es" ? "index.js" : `index.${format}.js`),
+      cssFileName: "styles",
       formats: ["es"],
     },
     rollupOptions: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ catalogs:
     '@storybook/react-vite':
       specifier: ^10.3.5
       version: 10.3.5
+    '@tailwindcss/vite':
+      specifier: ^4.2.2
+      version: 4.2.2
     '@testing-library/dom':
       specifier: ^10.4.1
       version: 10.4.1
@@ -72,6 +75,9 @@ catalogs:
     lint-staged:
       specifier: ^16.4.0
       version: 16.4.0
+    lucide-react:
+      specifier: ^1.8.0
+      version: 1.8.0
     oxfmt:
       specifier: ^0.46.0
       version: 0.46.0
@@ -93,6 +99,9 @@ catalogs:
     syncpack:
       specifier: ^14.3.0
       version: 14.3.0
+    tailwindcss:
+      specifier: ^4.2.2
+      version: 4.2.2
     typescript:
       specifier: ^6.0.3
       version: 6.0.3
@@ -158,10 +167,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
 
   packages/serverless-workflow-diagram-editor:
     dependencies:
@@ -189,13 +198,16 @@ importers:
         version: 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       '@storybook/addon-docs':
         specifier: 'catalog:'
-        version: 10.3.5(@types/react@19.2.14)(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
+        version: 10.3.5(@types/react@19.2.14)(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
       '@storybook/addon-vitest':
         specifier: 'catalog:'
         version: 10.3.5(@vitest/runner@4.1.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vitest@4.1.5)
       '@storybook/react-vite':
         specifier: 'catalog:'
-        version: 10.3.5(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
+        version: 10.3.5(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
+      '@tailwindcss/vite':
+        specifier: 'catalog:'
+        version: 4.2.2(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
       '@testing-library/dom':
         specifier: 'catalog:'
         version: 10.4.1
@@ -229,6 +241,9 @@ importers:
       jsdom:
         specifier: 'catalog:'
         version: 29.0.2
+      lucide-react:
+        specifier: 'catalog:'
+        version: 1.8.0(react@19.2.5)
       oxfmt:
         specifier: 'catalog:'
         version: 0.46.0
@@ -247,12 +262,15 @@ importers:
       storybook:
         specifier: 'catalog:'
         version: 10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      tailwindcss:
+        specifier: 'catalog:'
+        version: 4.2.2
       vite:
         specifier: 'catalog:'
-        version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
 
 packages:
 
@@ -1203,6 +1221,100 @@ packages:
       typescript:
         optional: true
 
+  '@tailwindcss/node@4.2.2':
+    resolution: {integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==}
+
+  '@tailwindcss/oxide-android-arm64@4.2.2':
+    resolution: {integrity: sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.2':
+    resolution: {integrity: sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.2.2':
+    resolution: {integrity: sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.2':
+    resolution: {integrity: sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.2':
+    resolution: {integrity: sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.2':
+    resolution: {integrity: sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
+    resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
+    resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.2':
+    resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.2':
+    resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.2':
+    resolution: {integrity: sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.2':
+    resolution: {integrity: sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.2.2':
+    resolution: {integrity: sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.2.2':
+    resolution: {integrity: sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
+
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
@@ -1609,6 +1721,10 @@ packages:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
     engines: {node: '>=14'}
 
+  enhanced-resolve@5.20.1:
+    resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
+    engines: {node: '>=10.13.0'}
+
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
@@ -1769,6 +1885,10 @@ packages:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
@@ -1900,6 +2020,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@1.8.0:
+    resolution: {integrity: sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -2232,6 +2357,13 @@ packages:
     resolution: {integrity: sha512-8/WtPPxxGFqE21JPFz6Bpw0m9BT3lzMYDcewJFj++EBPmCaDWowTnx0R4V7ofH/1z3HAIaAps6g2GHL76l1Y2g==}
     engines: {node: '>=14.17.0'}
     hasBin: true
+
+  tailwindcss@4.2.2:
+    resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
+
+  tapable@2.3.2:
+    resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
+    engines: {node: '>=6'}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -2746,11 +2878,11 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
-      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)
     optionalDependencies:
       typescript: 6.0.3
 
@@ -3058,10 +3190,10 @@ snapshots:
       axe-core: 4.11.3
       storybook: 10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
-  '@storybook/addon-docs@10.3.5(@types/react@19.2.14)(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))':
+  '@storybook/addon-docs@10.3.5(@types/react@19.2.14)(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
+      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
       '@storybook/icons': 2.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@storybook/react-dom-shim': 10.3.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       react: 19.2.5
@@ -3082,30 +3214,30 @@ snapshots:
       storybook: 10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
     optionalDependencies:
       '@vitest/runner': 4.1.5
-      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.3.5(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))':
+  '@storybook/builder-vite@10.3.5(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
-      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
+      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
       storybook: 10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       ts-dedent: 2.2.0
-      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.3.5(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))':
+  '@storybook/csf-plugin@10.3.5(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
       storybook: 10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.7
       rollup: 4.60.1
-      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)
 
   '@storybook/global@5.0.0': {}
 
@@ -3120,11 +3252,11 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       storybook: 10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
-  '@storybook/react-vite@10.3.5(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))':
+  '@storybook/react-vite@10.3.5(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
-      '@storybook/builder-vite': 10.3.5(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
+      '@storybook/builder-vite': 10.3.5(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
       '@storybook/react': 10.3.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -3134,7 +3266,7 @@ snapshots:
       resolve: 1.22.12
       storybook: 10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       tsconfig-paths: 4.2.0
-      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -3155,6 +3287,74 @@ snapshots:
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@tailwindcss/node@4.2.2':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.20.1
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.2.2
+
+  '@tailwindcss/oxide-android-arm64@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide@4.2.2':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.2.2
+      '@tailwindcss/oxide-darwin-arm64': 4.2.2
+      '@tailwindcss/oxide-darwin-x64': 4.2.2
+      '@tailwindcss/oxide-freebsd-x64': 4.2.2
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.2.2
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.2.2
+      '@tailwindcss/oxide-linux-arm64-musl': 4.2.2
+      '@tailwindcss/oxide-linux-x64-gnu': 4.2.2
+      '@tailwindcss/oxide-linux-x64-musl': 4.2.2
+      '@tailwindcss/oxide-wasm32-wasi': 4.2.2
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
+      '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
+
+  '@tailwindcss/vite@4.2.2(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))':
+    dependencies:
+      '@tailwindcss/node': 4.2.2
+      '@tailwindcss/oxide': 4.2.2
+      tailwindcss: 4.2.2
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -3280,7 +3480,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -3299,13 +3499,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -3342,7 +3542,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -3572,6 +3772,11 @@ snapshots:
 
   empathic@2.0.0: {}
 
+  enhanced-resolve@5.20.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.2
+
   entities@8.0.0: {}
 
   environment@1.1.0: {}
@@ -3657,8 +3862,7 @@ snapshots:
       minipass: 7.1.3
       path-scurry: 2.0.2
 
-  graceful-fs@4.2.11:
-    optional: true
+  graceful-fs@4.2.11: {}
 
   has-flag@4.0.0: {}
 
@@ -3710,6 +3914,8 @@ snapshots:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
+
+  jiti@2.6.1: {}
 
   js-tokens@10.0.0: {}
 
@@ -3839,6 +4045,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@1.8.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
 
   lz-string@1.5.0: {}
 
@@ -4225,6 +4435,10 @@ snapshots:
       syncpack-windows-arm64: 14.3.0
       syncpack-windows-x64: 14.3.0
 
+  tailwindcss@4.2.2: {}
+
+  tapable@2.3.2: {}
+
   tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
@@ -4295,7 +4509,7 @@ snapshots:
     dependencies:
       react: 19.2.5
 
-  vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3):
+  vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -4306,12 +4520,13 @@ snapshots:
       '@types/node': 25.6.0
       esbuild: 0.27.7
       fsevents: 2.3.3
+      jiti: 2.6.1
       yaml: 2.8.3
 
-  vitest@4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)):
+  vitest@4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -4328,7 +4543,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ catalog:
   "@storybook/addon-docs": ^10.3.5
   "@storybook/addon-vitest": ^10.3.5
   "@storybook/react-vite": ^10.3.5
+  "@tailwindcss/vite": ^4.2.2
   "@testing-library/dom": ^10.4.1
   "@testing-library/jest-dom": ^6.9.1
   "@testing-library/react": ^16.3.2
@@ -22,6 +23,7 @@ catalog:
   husky: ^9.1.7
   "js-yaml": ^4.1.1
   jsdom: ^29.0.2
+  lucide-react: ^1.8.0
   lint-staged: ^16.4.0
   oxfmt: ^0.46.0
   oxlint: ^1.61.0
@@ -30,6 +32,7 @@ catalog:
   rimraf: ^6.1.3
   storybook: ^10.3.5
   syncpack: ^14.3.0
+  tailwindcss: ^4.2.2
   typescript: ^6.0.3
   vite: ^8.0.10
   vitest: ^4.1.5


### PR DESCRIPTION
Closes https://github.com/serverlessworkflow/editor/issues/104

## Summary
Add styling dependencies and apply styling to the error page

## Changes
- Add Tailwind v4 and `lucide-react` icons
- Configure tailwind with `dec` prefix and add scope all styles under a `dec-root` wrapper class
- Add Tailwind `@custom-variant` for selector-based dark mode
- Update color mode to work with tailwind
- Add `useResolvedColorMode` hook that resolves `system` to `light` or `dark` and listens for changes
- Apply a `.dark` class to `dec-root` based on resolved color mode
- Add styling to `ErrorPage` for both light and dark modes
- Add and update stories

https://github.com/user-attachments/assets/011a9b93-acd9-4cd3-a906-aae0f24b18dd

