### PR TITLE
fix: Allow pnpm to regenerate lockfile for dependabot

### DIFF
--- a/.github/workflows/ci_build.yaml
+++ b/.github/workflows/ci_build.yaml
@@ -62,7 +62,7 @@ jobs:
           pnpm -r exec node -e "process.exit(require('./package.json').version === '0.0.0' ? 0 : 1)"
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' && '--no-frozen-lockfile' || '' }}
 
       - name: Install Playwright browsers
         run: pnpm playwright:install:ci


### PR DESCRIPTION
## Description
Dependabot PRs open but cannot be merged due to the lockfile being out of sync. See the following error

```
Run pnpm install
Scope: all 3 workspace projects
 ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with <ROOT>\package.json

Note that in CI environments this setting is true by default. If you still need to run install in such cases, use "pnpm install --no-frozen-lockfile"

  Failure reason:
  specifiers in the lockfile don't match specifiers in package.json:
* 1 dependencies are mismatched:
  - lint-staged (lockfile: 17.0.2, manifest: catalog:)
```
PR reference https://github.com/serverlessworkflow/editor/pull/137

## Fix
Conditionally append `--no-frozen-locakfile` when `github.event.pull_request_user.login` is `dependabot`. Once merged, close the current dependabot PR and allow it to recreate