### PR TITLE
feat: Add custom catch container node

### DIFF
--- a/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/diagramBuilder.ts
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/diagramBuilder.ts
@@ -79,7 +79,7 @@ function buildReactFlowNode(
   const type = resolveNodeType(graphNode, catchContainerIds);
   // There is no corresponding react flow component implemented
   if (!Object.keys(ReactFlowNodeTypes).includes(type)) {
-    throw new Error(`Unsupported GraphNodeType: ${type}!`);
+    throw new Error(`Unsupported React flow node type: ${type}!`);
   }
 
   return {

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/diagramBuilder.ts
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/diagramBuilder.ts
@@ -16,7 +16,7 @@
 
 import * as RF from "@xyflow/react";
 import { buildFlatGraph } from "../../core";
-import { BaseNodeData, ReactFlowNodeTypes } from "../nodes/Nodes";
+import { BaseNodeData, CATCH_CONTAINER_NODE_TYPE, ReactFlowNodeTypes } from "../nodes/Nodes";
 import { BaseEdgeData, EdgeTypes } from "../edges/Edges";
 import * as sdk from "@serverlessworkflow/sdk";
 import { applyAutoLayout, DEFAULT_NODE_SIZE } from "./autoLayout";
@@ -46,15 +46,45 @@ export function edgeSourceAndTargetExist(
   return nodeIdSet.has(graphEdge.sourceId) && nodeIdSet.has(graphEdge.targetId);
 }
 
-function buildReactFlowNode(graphNode: sdk.FlatGraph | sdk.FlatGraphNode): RF.Node<BaseNodeData> {
+/* Return ids of catch nodes that are containers (have child nodes with parentIds pointing to them) */
+export function getCatchContainerNodeIds(graph: sdk.FlatGraph): Set<string> {
+  const parentIds = new Set<string>();
+  for (const node of graph.nodes) {
+    if (node.parentId) {
+      parentIds.add(node.parentId);
+    }
+  }
+
+  const containerIds = new Set<string>();
+  for (const node of graph.nodes) {
+    if (node.type === sdk.GraphNodeType.Catch && parentIds.has(node.id)) {
+      containerIds.add(node.id);
+    }
+  }
+
+  return containerIds;
+}
+
+function resolveNodeType(graphNode: sdk.FlatGraphNode, catchContainerIds: Set<string>): string {
+  if (graphNode.type === sdk.GraphNodeType.Catch && catchContainerIds.has(graphNode.id)) {
+    return CATCH_CONTAINER_NODE_TYPE;
+  }
+  return graphNode.type;
+}
+
+function buildReactFlowNode(
+  graphNode: sdk.FlatGraphNode,
+  catchContainerIds: Set<string>,
+): RF.Node<BaseNodeData> {
+  const type = resolveNodeType(graphNode, catchContainerIds);
   // There is no corresponding react flow component implemented
-  if (!Object.keys(ReactFlowNodeTypes).includes(graphNode.type)) {
-    throw new Error(`Unsupported GraphNodeType: ${graphNode.type}!`);
+  if (!Object.keys(ReactFlowNodeTypes).includes(type)) {
+    throw new Error(`Unsupported GraphNodeType: ${type}!`);
   }
 
   return {
     id: graphNode.id,
-    type: graphNode.type,
+    type,
     data: {
       label: graphNode.label ?? "",
       ...(graphNode.task !== undefined && { task: structuredClone(graphNode.task) }),
@@ -89,11 +119,12 @@ export function buildDiagramElements(model: sdk.Specification.Workflow | null): 
 
   if (model) {
     const graph = buildFlatGraph(model);
+    const catchContainerIds = getCatchContainerNodeIds(graph);
 
     graph.nodes.forEach((graphNode) => {
       // TODO: only nodes on root level are supported for now
       if (graphNode.parentId === "root") {
-        nodes.push(buildReactFlowNode(graphNode));
+        nodes.push(buildReactFlowNode(graphNode, catchContainerIds));
       }
     });
 

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/nodes/Nodes.tsx
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/nodes/Nodes.tsx
@@ -21,7 +21,9 @@ import { type LeafNodeType, taskNodeConfigMap } from "./taskNodeConfig";
 import { Info } from "lucide-react";
 import { getCallSubType, getListenSubType, getRunSubType } from "../../core";
 
-// Node types must match sdk GraphNodeType enum
+export const CATCH_CONTAINER_NODE_TYPE = "catch-container";
+/* Node types are primarily keyed by the sdk GraphNodeType enum, with custom
+   React Flow-only node types such as catch-container added where needed. */
 export const ReactFlowNodeTypes: RF.NodeTypes = {
   [GraphNodeType.Start]: StartNode,
   [GraphNodeType.End]: EndNode,
@@ -38,6 +40,7 @@ export const ReactFlowNodeTypes: RF.NodeTypes = {
   [GraphNodeType.TryCatch]: TryCatchNode,
   [GraphNodeType.Try]: TryNode,
   [GraphNodeType.Catch]: CatchNode,
+  [CATCH_CONTAINER_NODE_TYPE]: CatchContainerNode,
   [GraphNodeType.Wait]: WaitNode,
 };
 
@@ -248,6 +251,18 @@ export function TryNode({ id, data, selected, type }: RF.NodeProps<TryNodeType>)
 export type CatchNodeType = RF.Node<BaseNodeData, typeof GraphNodeType.Catch>;
 export function CatchNode({ id, data, selected, type }: RF.NodeProps<CatchNodeType>) {
   return <TaskNodeContent id={id} data={data} selected={selected} type={type} />;
+}
+
+/* catch container node */
+export type CatchContainerNodeType = RF.Node<BaseNodeData, typeof CATCH_CONTAINER_NODE_TYPE>;
+export function CatchContainerNode({
+  id,
+  data,
+  selected,
+  type,
+}: RF.NodeProps<CatchContainerNodeType>) {
+  // TODO: This component is just a placeholder
+  return <PlaceholderContent id={id} data={data} selected={selected} type={type} />;
 }
 
 /* wait leaf node */

--- a/packages/serverless-workflow-diagram-editor/tests/core/graph.test.ts
+++ b/packages/serverless-workflow-diagram-editor/tests/core/graph.test.ts
@@ -15,25 +15,9 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { FlatGraph, FlatGraphNode, GraphNodeType } from "@serverlessworkflow/sdk";
+import { FlatGraphNode, GraphNodeType } from "@serverlessworkflow/sdk";
 import { getNodesByType, fixNodesConnections } from "../../src/core/graph";
-
-function createFlatGraph(
-  nodes: FlatGraphNode[],
-  edges: Array<{ id: string; sourceId: string; targetId: string; label: string }>,
-): FlatGraph {
-  const entryNode = nodes.find((n) => n.type === GraphNodeType.Entry);
-  const exitNode = nodes.find((n) => n.type === GraphNodeType.Exit);
-
-  return {
-    id: "root",
-    type: GraphNodeType.Do,
-    nodes,
-    edges,
-    entryNode,
-    exitNode,
-  } as FlatGraph;
-}
+import { createFlatGraph } from "../test-utils/graph-helpers";
 
 describe("graph utils", () => {
   describe("getNodesByType", () => {

--- a/packages/serverless-workflow-diagram-editor/tests/react-flow/diagram/diagramBuilder.test.ts
+++ b/packages/serverless-workflow-diagram-editor/tests/react-flow/diagram/diagramBuilder.test.ts
@@ -16,11 +16,12 @@
 
 import { describe, it, expect, beforeAll } from "vitest";
 import * as RF from "@xyflow/react";
-import { GraphNodeType } from "@serverlessworkflow/sdk";
+import { FlatGraphNode, GraphNodeType } from "@serverlessworkflow/sdk";
 import {
   getEdgeType,
   edgeSourceAndTargetExist,
   buildDiagramElements,
+  getCatchContainerNodeIds,
 } from "../../../src/react-flow/diagram/diagramBuilder";
 import { EdgeTypes } from "../../../src/react-flow/edges/Edges";
 import { parseWorkflow } from "../../../src/core";
@@ -28,6 +29,7 @@ import {
   BASIC_VALID_WORKFLOW_JSON,
   BASIC_VALID_WORKFLOW_JSON_TASKS,
 } from "../../fixtures/workflows";
+import { createFlatGraph } from "../../test-utils/graph-helpers";
 
 // Type alias for diagram elements to reduce verbosity
 type DiagramElements = ReturnType<typeof buildDiagramElements>;
@@ -361,6 +363,141 @@ describe("diagramBuilder", () => {
 
         expect(diagram.nodes.length).toBeGreaterThan(0);
       });
+    });
+  });
+
+  describe("getCatchContainerNodeIds", () => {
+    it("should not include leaf catch nodes", () => {
+      const sdkGraph = createFlatGraph(
+        [
+          {
+            id: "start",
+            type: GraphNodeType.Start,
+          } as FlatGraphNode,
+          {
+            id: "end",
+            type: GraphNodeType.End,
+          } as FlatGraphNode,
+          {
+            id: "/do/0/CatchError",
+            type: GraphNodeType.Catch,
+            label: "CatchError",
+          } as FlatGraphNode,
+        ],
+        [],
+      );
+
+      const result = getCatchContainerNodeIds(sdkGraph);
+      expect(result.size).toBe(0);
+    });
+
+    it("should include catch nodes that have children", () => {
+      const sdkGraph = createFlatGraph(
+        [
+          {
+            id: "start",
+            type: GraphNodeType.Start,
+          } as FlatGraphNode,
+          {
+            id: "end",
+            type: GraphNodeType.End,
+          } as FlatGraphNode,
+          {
+            id: "/do/0/CatchContainer",
+            type: GraphNodeType.Catch,
+            label: "CatchContainer",
+          } as FlatGraphNode,
+          {
+            id: "/do/0/CatchContainer-entry-node",
+            type: GraphNodeType.Entry,
+            parentId: "/do/0/CatchContainer",
+          } as FlatGraphNode,
+          {
+            id: "/do/0/CatchContainer-exit-node",
+            type: GraphNodeType.Exit,
+            parentId: "/do/0/CatchContainer",
+          } as FlatGraphNode,
+          {
+            id: "/do/0/CatchContainer/do/0/step1",
+            type: GraphNodeType.Set,
+            label: "step1",
+            parentId: "/do/0/CatchContainer",
+          } as FlatGraphNode,
+        ],
+        [],
+      );
+
+      const result = getCatchContainerNodeIds(sdkGraph);
+
+      expect(result.has("/do/0/CatchContainer")).toBe(true);
+      expect(result.size).toBe(1);
+    });
+
+    it("should not include non-catch nodes", () => {
+      const sdkGraph = createFlatGraph(
+        [
+          {
+            id: "start",
+            type: GraphNodeType.Start,
+          } as FlatGraphNode,
+          {
+            id: "end",
+            type: GraphNodeType.End,
+          } as FlatGraphNode,
+          {
+            id: "/do/0/step1",
+            type: GraphNodeType.Set,
+            label: "step1",
+          } as FlatGraphNode,
+          {
+            id: "/do/0/step2",
+            type: GraphNodeType.Call,
+            label: "step2",
+          } as FlatGraphNode,
+        ],
+        [],
+      );
+
+      const result = getCatchContainerNodeIds(sdkGraph);
+      expect(result.size).toBe(0);
+    });
+
+    it("should inclyde nested catch containers insode a parent container", () => {
+      const sdkGraph = createFlatGraph(
+        [
+          {
+            id: "start",
+            type: GraphNodeType.Start,
+          } as FlatGraphNode,
+          {
+            id: "end",
+            type: GraphNodeType.End,
+          } as FlatGraphNode,
+          {
+            id: "/do/0/TryCatch",
+            type: GraphNodeType.TryCatch,
+            label: "TryCatch",
+          } as FlatGraphNode,
+          {
+            id: "/do/0/TryCatch/catch",
+            type: GraphNodeType.Catch,
+            label: "catch",
+            parentId: "/do/0/TryCatch",
+          } as FlatGraphNode,
+          {
+            id: "/do/0/TryCatch/catch/do/0/recover",
+            type: GraphNodeType.Set,
+            label: "recover",
+            parentId: "/do/0/TryCatch/catch",
+          } as FlatGraphNode,
+        ],
+        [],
+      );
+
+      const result = getCatchContainerNodeIds(sdkGraph);
+
+      expect(result.has("/do/0/TryCatch/catch")).toBe(true);
+      expect(result.has("/do/0/TryCatch")).toBe(false);
     });
   });
 });

--- a/packages/serverless-workflow-diagram-editor/tests/react-flow/diagram/diagramBuilder.test.ts
+++ b/packages/serverless-workflow-diagram-editor/tests/react-flow/diagram/diagramBuilder.test.ts
@@ -462,7 +462,7 @@ describe("diagramBuilder", () => {
       expect(result.size).toBe(0);
     });
 
-    it("should inclyde nested catch containers insode a parent container", () => {
+    it("should include nested catch containers inside a parent container", () => {
       const sdkGraph = createFlatGraph(
         [
           {

--- a/packages/serverless-workflow-diagram-editor/tests/test-utils/graph-helpers.ts
+++ b/packages/serverless-workflow-diagram-editor/tests/test-utils/graph-helpers.ts
@@ -14,6 +14,21 @@
  * limitations under the License.
  */
 
-export { renderWithProviders } from "./render-helpers";
-export { t } from "./translation-helpers";
-export { createFlatGraph } from "./graph-helpers";
+import { FlatGraph, FlatGraphNode, GraphNodeType } from "@serverlessworkflow/sdk";
+
+export function createFlatGraph(
+  nodes: FlatGraphNode[],
+  edges: Array<{ id: string; sourceId: string; targetId: string; label: string }>,
+): FlatGraph {
+  const entryNode = nodes.find((n) => n.type === GraphNodeType.Entry);
+  const exitNode = nodes.find((n) => n.type === GraphNodeType.Exit);
+
+  return {
+    id: "root",
+    type: GraphNodeType.Do,
+    nodes,
+    edges,
+    entryNode,
+    exitNode,
+  } as FlatGraph;
+}


### PR DESCRIPTION
Closes https://github.com/serverlessworkflow/editor/issues/141

## Summary
Resolve catch leaf vs catch container nodes at ReactFlow boundary as this is a rendering concern

## Changes
- Get a set of catch nodes that have children, identifying them as containers
- Resolve catch nodes by mapping them to a custom type
- Add catch container node to nodes
- Extract shared createFlatGraph function as test helper