### PR TITLE
feat: Add entry/exit node styling

### DIFF
--- a/.changeset/entry-exit-nodes.md
+++ b/.changeset/entry-exit-nodes.md
@@ -1,0 +1,5 @@
+---
+"@serverlessworkflow/diagram-editor": minor
+---
+
+Add entry/exit container nodes

--- a/packages/serverless-workflow-diagram-editor/src/i18n/locales/en.ts
+++ b/packages/serverless-workflow-diagram-editor/src/i18n/locales/en.ts
@@ -36,6 +36,8 @@ export const en = {
   "sidebar.sectionSource": "Source",
   "sidebar.viewSource": "View source",
   "sidebar.noDetails": "No additional details for this node",
+  "node.entry": "Entry",
+  "node.exit": "Exit",
 } as const;
 
 export type TranslationKeys = keyof typeof en;

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.css
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.css
@@ -70,7 +70,7 @@
 /* custom nodes */
 @layer custom-nodes {
   .dec-root .node-label-container {
-    @apply dec:whitespace-pre 
+    @apply dec:whitespace-pre
             dec:p-0.75
             dec:text-black
             dec:text-sm;
@@ -81,11 +81,11 @@
   }
 
   .dec-root .custom-node-container {
-    @apply dec:rounded-[5px] 
-            dec:bg-white 
-            dec:border dec:border-black 
-            dec:transition-[border,box-shadow] 
-            dec:h-full 
+    @apply dec:rounded-[5px]
+            dec:bg-white
+            dec:border dec:border-black
+            dec:transition-[border,box-shadow]
+            dec:h-full
             dec:w-full;
   }
 
@@ -95,26 +95,26 @@
   }
 
   .dec-root .custom-node-container:hover {
-    @apply dec:hover:border dec:hover:border-black 
-            dec:hover:shadow-[0_0_10px_rgba(0,65,208,0.3)] 
-            dec:hover:h-full 
+    @apply dec:hover:border dec:hover:border-black
+            dec:hover:shadow-[0_0_10px_rgba(0,65,208,0.3)]
+            dec:hover:h-full
             dec:hover:w-full;
   }
 
   .dec-root.dark .custom-node-container:hover {
-    @apply dec:hover:border-[#5dafd5] 
+    @apply dec:hover:border-[#5dafd5]
             dec:hover:shadow-[0_0_10px_rgba(255,255,255,0.3)];
   }
 
   .dec-root .custom-node-container.selected {
-    @apply dec:bg-[#aebbd5] 
-            dec:border dec:border-black 
+    @apply dec:bg-[#aebbd5]
+            dec:border dec:border-black
             dec:shadow-[0_0_10px_rgba(1,79,248,0.3)];
   }
 
   .dec-root.dark .custom-node-container.selected {
-    @apply dec:bg-[#727676] 
-            dec:border-[#4324dc] 
+    @apply dec:bg-[#727676]
+            dec:border-[#4324dc]
             dec:shadow-[0_0_10px_rgba(255,255,255,0.3)];
   }
 
@@ -288,21 +288,29 @@
   .dec-root .dec-task-node-badge,
   .dec-root .dec-task-node-badge-custom {
     color: color-mix(in srgb, var(--task-node-color) 60%, black);
-    background-color: color-mix(in srgb, var(--task-node-color) 12%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--task-node-color) 12%,
+      transparent
+    );
   }
 
   .dec-root.dark .dec-task-node-badge,
   .dec-root.dark .dec-task-node-badge-custom {
     color: color-mix(in srgb, var(--task-node-color) 18%, white);
-    background-color: color-mix(in srgb, var(--task-node-color) 40%, transparent);
+    background-color: color-mix(
+      in srgb,
+      var(--task-node-color) 40%,
+      transparent
+    );
   }
 
   .dec-root .dec-task-node-badge {
     @apply dec:ml-auto
-      dec:shrink-0 
+      dec:shrink-0
       dec:rounded
-      dec:px-2 
-      dec:py-0.5 
+      dec:px-2
+      dec:py-0.5
       dec:text-[8px]
       dec:font-semibold
       dec:uppercase

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.css
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.css
@@ -70,7 +70,7 @@
 /* custom nodes */
 @layer custom-nodes {
   .dec-root .node-label-container {
-    @apply dec:whitespace-pre
+    @apply dec:whitespace-pre 
             dec:p-0.75
             dec:text-black
             dec:text-sm;
@@ -81,11 +81,11 @@
   }
 
   .dec-root .custom-node-container {
-    @apply dec:rounded-[5px]
-            dec:bg-white
-            dec:border dec:border-black
-            dec:transition-[border,box-shadow]
-            dec:h-full
+    @apply dec:rounded-[5px] 
+            dec:bg-white 
+            dec:border dec:border-black 
+            dec:transition-[border,box-shadow] 
+            dec:h-full 
             dec:w-full;
   }
 
@@ -95,26 +95,26 @@
   }
 
   .dec-root .custom-node-container:hover {
-    @apply dec:hover:border dec:hover:border-black
-            dec:hover:shadow-[0_0_10px_rgba(0,65,208,0.3)]
-            dec:hover:h-full
+    @apply dec:hover:border dec:hover:border-black 
+            dec:hover:shadow-[0_0_10px_rgba(0,65,208,0.3)] 
+            dec:hover:h-full 
             dec:hover:w-full;
   }
 
   .dec-root.dark .custom-node-container:hover {
-    @apply dec:hover:border-[#5dafd5]
+    @apply dec:hover:border-[#5dafd5] 
             dec:hover:shadow-[0_0_10px_rgba(255,255,255,0.3)];
   }
 
   .dec-root .custom-node-container.selected {
-    @apply dec:bg-[#aebbd5]
-            dec:border dec:border-black
+    @apply dec:bg-[#aebbd5] 
+            dec:border dec:border-black 
             dec:shadow-[0_0_10px_rgba(1,79,248,0.3)];
   }
 
   .dec-root.dark .custom-node-container.selected {
-    @apply dec:bg-[#727676]
-            dec:border-[#4324dc]
+    @apply dec:bg-[#727676] 
+            dec:border-[#4324dc] 
             dec:shadow-[0_0_10px_rgba(255,255,255,0.3)];
   }
 
@@ -288,29 +288,21 @@
   .dec-root .dec-task-node-badge,
   .dec-root .dec-task-node-badge-custom {
     color: color-mix(in srgb, var(--task-node-color) 60%, black);
-    background-color: color-mix(
-      in srgb,
-      var(--task-node-color) 12%,
-      transparent
-    );
+    background-color: color-mix(in srgb, var(--task-node-color) 12%, transparent);
   }
 
   .dec-root.dark .dec-task-node-badge,
   .dec-root.dark .dec-task-node-badge-custom {
     color: color-mix(in srgb, var(--task-node-color) 18%, white);
-    background-color: color-mix(
-      in srgb,
-      var(--task-node-color) 40%,
-      transparent
-    );
+    background-color: color-mix(in srgb, var(--task-node-color) 40%, transparent);
   }
 
   .dec-root .dec-task-node-badge {
     @apply dec:ml-auto
-      dec:shrink-0
+      dec:shrink-0 
       dec:rounded
-      dec:px-2
-      dec:py-0.5
+      dec:px-2 
+      dec:py-0.5 
       dec:text-[8px]
       dec:font-semibold
       dec:uppercase
@@ -330,6 +322,42 @@
       dec:font-semibold;
   }
   /* end task leaf nodes */
+
+  /* start terminal markers (entry/exit) */
+  .dec-root .dec-terminal-node {
+    @apply dec:flex
+      dec:h-full
+      dec:w-full
+      dec:items-center
+      dec:justify-center
+      dec:gap-1.5
+      dec:rounded-full
+      dec:border
+      dec:border-slate-300
+      dec:bg-slate-100
+      dec:px-2.5
+      dec:text-[10px]
+      dec:font-medium
+      dec:uppercase
+      dec:leading-none
+      dec:tracking-wide
+      dec:text-slate-600;
+  }
+
+  .dec-root.dark .dec-terminal-node {
+    @apply dec:border-slate-600
+      dec:bg-slate-800
+      dec:text-slate-300;
+  }
+
+  .dec-root .dec-terminal-node-icon {
+    @apply dec:shrink-0;
+  }
+
+  .dec-root .dec-terminal-node-label {
+    @apply dec:truncate;
+  }
+  /* end terminal markers */
 }
 
 /* custom edges */

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.tsx
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.tsx
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-import * as RF from "@xyflow/react";
-import { ReactFlowNodeTypes } from "../nodes/Nodes";
-import "@xyflow/react/dist/style.css";
-import "./Diagram.css";
-import { ResolvedColorMode } from "../../types/colorMode";
-import { ReactFlowEdgeTypes } from "../edges/Edges";
-import { useDiagramEditorContext } from "../../store/DiagramEditorContext";
-import { buildDiagramElements } from "./diagramBuilder";
-import { SidebarTrigger } from "@/components/ui/sidebar";
-import { applyAutoLayout } from "./autoLayout";
+import * as React from 'react';
+import * as RF from '@xyflow/react';
+import { ReactFlowNodeTypes } from '../nodes/Nodes';
+import '@xyflow/react/dist/style.css';
+import './Diagram.css';
+import { ResolvedColorMode } from '../../types/colorMode';
+import { ReactFlowEdgeTypes } from '../edges/Edges';
+import { useDiagramEditorContext } from '../../store/DiagramEditorContext';
+import { buildDiagramElements } from './diagramBuilder';
+import { SidebarTrigger } from '@/components/ui/sidebar';
+import { applyAutoLayout } from './autoLayout';
 
 const FIT_VIEW_OPTIONS: RF.FitViewOptions = {
   maxZoom: 1,
@@ -45,10 +45,17 @@ export type DiagramProps = {
   colorMode?: ResolvedColorMode;
 };
 
-export const Diagram = ({ divRef, ref, colorMode = "light" }: DiagramProps) => {
+export const Diagram = ({ divRef, ref, colorMode = 'light' }: DiagramProps) => {
   const reactFlowInstance: RF.ReactFlowInstance = RF.useReactFlow();
-  const { model, nodes, edges, isReadOnly, setNodes, setEdges, setSelectedNodeId } =
-    useDiagramEditorContext();
+  const {
+    model,
+    nodes,
+    edges,
+    isReadOnly,
+    setNodes,
+    setEdges,
+    setSelectedNodeId,
+  } = useDiagramEditorContext();
 
   const [minimapVisible, setMinimapVisible] = React.useState(false);
 
@@ -63,15 +70,18 @@ export const Diagram = ({ divRef, ref, colorMode = "light" }: DiagramProps) => {
   );
 
   const onNodesChange = React.useCallback<RF.OnNodesChange>(
-    (changes) => setNodes((nodesSnapshot) => RF.applyNodeChanges(changes, nodesSnapshot)),
+    (changes) =>
+      setNodes((nodesSnapshot) => RF.applyNodeChanges(changes, nodesSnapshot)),
     [setNodes],
   );
   const onEdgesChange = React.useCallback<RF.OnEdgesChange>(
-    (changes) => setEdges((edgesSnapshot) => RF.applyEdgeChanges(changes, edgesSnapshot)),
+    (changes) =>
+      setEdges((edgesSnapshot) => RF.applyEdgeChanges(changes, edgesSnapshot)),
     [setEdges],
   );
   const onSelectionChange = React.useCallback<RF.OnSelectionChangeFunc>(
-    ({ nodes: selectedNodes }) => setSelectedNodeId(selectedNodes[0]?.id ?? null),
+    ({ nodes: selectedNodes }) =>
+      setSelectedNodeId(selectedNodes[0]?.id ?? null),
     [setSelectedNodeId],
   );
 
@@ -101,11 +111,11 @@ export const Diagram = ({ divRef, ref, colorMode = "light" }: DiagramProps) => {
         })
         .catch((error) => {
           // Ignore abort errors as they are expected when cancelling
-          if (error.name === "AbortError") {
+          if (error.name === 'AbortError') {
             return;
           }
           // Handle other auto-layout errors to prevent unhandled promise rejections
-          console.error("Failed to apply auto-layout:", error);
+          console.error('Failed to apply auto-layout:', error);
         });
     }, 100); // 150ms debounce delay
 
@@ -133,8 +143,12 @@ export const Diagram = ({ divRef, ref, colorMode = "light" }: DiagramProps) => {
   return (
     <div
       ref={divRef}
-      className={isReadOnly ? "dec:h-full dec:relative read-only" : "dec:h-full dec:relative"}
-      data-testid={"diagram-container"}
+      className={
+        isReadOnly
+          ? 'dec:h-full dec:relative read-only'
+          : 'dec:h-full dec:relative'
+      }
+      data-testid={'diagram-container'}
     >
       <RF.ReactFlow
         nodeTypes={ReactFlowNodeTypes}
@@ -160,11 +174,13 @@ export const Diagram = ({ divRef, ref, colorMode = "light" }: DiagramProps) => {
             height: 10,
           },
         }}
-        data-testid={"react-flow-canvas"}
+        data-testid={'react-flow-canvas'}
         nodesDraggable={!isReadOnly}
         nodesConnectable={!isReadOnly}
       >
-        {minimapVisible && <RF.MiniMap pannable zoomable position={"top-right"} />}
+        {minimapVisible && (
+          <RF.MiniMap pannable zoomable position={'top-right'} />
+        )}
 
         <RF.Panel position="top-right">
           <SidebarTrigger />
@@ -172,12 +188,17 @@ export const Diagram = ({ divRef, ref, colorMode = "light" }: DiagramProps) => {
 
         <RF.Controls
           fitViewOptions={FIT_VIEW_OPTIONS}
-          position={"bottom-right"}
+          position={'bottom-right'}
           showInteractive={false}
         >
-          <RF.ControlButton onClick={() => setMinimapVisible(!minimapVisible)}>M</RF.ControlButton>
+          <RF.ControlButton onClick={() => setMinimapVisible(!minimapVisible)}>
+            M
+          </RF.ControlButton>
         </RF.Controls>
-        <RF.Background className="diagram-background" variant={RF.BackgroundVariant.Cross} />
+        <RF.Background
+          className="diagram-background"
+          variant={RF.BackgroundVariant.Cross}
+        />
       </RF.ReactFlow>
     </div>
   );

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.tsx
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.tsx
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-import * as React from 'react';
-import * as RF from '@xyflow/react';
-import { ReactFlowNodeTypes } from '../nodes/Nodes';
-import '@xyflow/react/dist/style.css';
-import './Diagram.css';
-import { ResolvedColorMode } from '../../types/colorMode';
-import { ReactFlowEdgeTypes } from '../edges/Edges';
-import { useDiagramEditorContext } from '../../store/DiagramEditorContext';
-import { buildDiagramElements } from './diagramBuilder';
-import { SidebarTrigger } from '@/components/ui/sidebar';
-import { applyAutoLayout } from './autoLayout';
+import * as React from "react";
+import * as RF from "@xyflow/react";
+import { ReactFlowNodeTypes } from "../nodes/Nodes";
+import "@xyflow/react/dist/style.css";
+import "./Diagram.css";
+import { ResolvedColorMode } from "../../types/colorMode";
+import { ReactFlowEdgeTypes } from "../edges/Edges";
+import { useDiagramEditorContext } from "../../store/DiagramEditorContext";
+import { buildDiagramElements } from "./diagramBuilder";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+import { applyAutoLayout } from "./autoLayout";
 
 const FIT_VIEW_OPTIONS: RF.FitViewOptions = {
   maxZoom: 1,
@@ -45,17 +45,10 @@ export type DiagramProps = {
   colorMode?: ResolvedColorMode;
 };
 
-export const Diagram = ({ divRef, ref, colorMode = 'light' }: DiagramProps) => {
+export const Diagram = ({ divRef, ref, colorMode = "light" }: DiagramProps) => {
   const reactFlowInstance: RF.ReactFlowInstance = RF.useReactFlow();
-  const {
-    model,
-    nodes,
-    edges,
-    isReadOnly,
-    setNodes,
-    setEdges,
-    setSelectedNodeId,
-  } = useDiagramEditorContext();
+  const { model, nodes, edges, isReadOnly, setNodes, setEdges, setSelectedNodeId } =
+    useDiagramEditorContext();
 
   const [minimapVisible, setMinimapVisible] = React.useState(false);
 
@@ -70,18 +63,15 @@ export const Diagram = ({ divRef, ref, colorMode = 'light' }: DiagramProps) => {
   );
 
   const onNodesChange = React.useCallback<RF.OnNodesChange>(
-    (changes) =>
-      setNodes((nodesSnapshot) => RF.applyNodeChanges(changes, nodesSnapshot)),
+    (changes) => setNodes((nodesSnapshot) => RF.applyNodeChanges(changes, nodesSnapshot)),
     [setNodes],
   );
   const onEdgesChange = React.useCallback<RF.OnEdgesChange>(
-    (changes) =>
-      setEdges((edgesSnapshot) => RF.applyEdgeChanges(changes, edgesSnapshot)),
+    (changes) => setEdges((edgesSnapshot) => RF.applyEdgeChanges(changes, edgesSnapshot)),
     [setEdges],
   );
   const onSelectionChange = React.useCallback<RF.OnSelectionChangeFunc>(
-    ({ nodes: selectedNodes }) =>
-      setSelectedNodeId(selectedNodes[0]?.id ?? null),
+    ({ nodes: selectedNodes }) => setSelectedNodeId(selectedNodes[0]?.id ?? null),
     [setSelectedNodeId],
   );
 
@@ -111,11 +101,11 @@ export const Diagram = ({ divRef, ref, colorMode = 'light' }: DiagramProps) => {
         })
         .catch((error) => {
           // Ignore abort errors as they are expected when cancelling
-          if (error.name === 'AbortError') {
+          if (error.name === "AbortError") {
             return;
           }
           // Handle other auto-layout errors to prevent unhandled promise rejections
-          console.error('Failed to apply auto-layout:', error);
+          console.error("Failed to apply auto-layout:", error);
         });
     }, 100); // 150ms debounce delay
 
@@ -143,12 +133,8 @@ export const Diagram = ({ divRef, ref, colorMode = 'light' }: DiagramProps) => {
   return (
     <div
       ref={divRef}
-      className={
-        isReadOnly
-          ? 'dec:h-full dec:relative read-only'
-          : 'dec:h-full dec:relative'
-      }
-      data-testid={'diagram-container'}
+      className={isReadOnly ? "dec:h-full dec:relative read-only" : "dec:h-full dec:relative"}
+      data-testid={"diagram-container"}
     >
       <RF.ReactFlow
         nodeTypes={ReactFlowNodeTypes}
@@ -174,13 +160,11 @@ export const Diagram = ({ divRef, ref, colorMode = 'light' }: DiagramProps) => {
             height: 10,
           },
         }}
-        data-testid={'react-flow-canvas'}
+        data-testid={"react-flow-canvas"}
         nodesDraggable={!isReadOnly}
         nodesConnectable={!isReadOnly}
       >
-        {minimapVisible && (
-          <RF.MiniMap pannable zoomable position={'top-right'} />
-        )}
+        {minimapVisible && <RF.MiniMap pannable zoomable position={"top-right"} />}
 
         <RF.Panel position="top-right">
           <SidebarTrigger />
@@ -188,17 +172,12 @@ export const Diagram = ({ divRef, ref, colorMode = 'light' }: DiagramProps) => {
 
         <RF.Controls
           fitViewOptions={FIT_VIEW_OPTIONS}
-          position={'bottom-right'}
+          position={"bottom-right"}
           showInteractive={false}
         >
-          <RF.ControlButton onClick={() => setMinimapVisible(!minimapVisible)}>
-            M
-          </RF.ControlButton>
+          <RF.ControlButton onClick={() => setMinimapVisible(!minimapVisible)}>M</RF.ControlButton>
         </RF.Controls>
-        <RF.Background
-          className="diagram-background"
-          variant={RF.BackgroundVariant.Cross}
-        />
+        <RF.Background className="diagram-background" variant={RF.BackgroundVariant.Cross} />
       </RF.ReactFlow>
     </div>
   );

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/autoLayout.ts
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/autoLayout.ts
@@ -14,9 +14,13 @@
  * limitations under the License.
  */
 
-import type { ElkNode, LayoutOptions, ElkExtendedEdge } from "elkjs/lib/elk.bundled.js";
-import { processElkLayout } from "@/core";
-import { ReactFlowGraph } from "./diagramBuilder";
+import type {
+  ElkNode,
+  LayoutOptions,
+  ElkExtendedEdge,
+} from 'elkjs/lib/elk.bundled.js';
+import { processElkLayout } from '@/core';
+import { ReactFlowGraph } from './diagramBuilder';
 
 // Defaults
 export const DEFAULT_NODE_SIZE = {
@@ -39,30 +43,32 @@ export type Size = {
 export type WayPoints = Point[];
 
 export const ROOT_LAYOUT_OPTIONS: LayoutOptions = {
-  "org.eclipse.elk.algorithm": "org.eclipse.elk.layered",
-  "org.eclipse.elk.direction": "DOWN",
-  "org.eclipse.elk.layered.nodePlacement.strategy": "BRANDES_KOEPF",
-  "org.eclipse.elk.layered.nodePlacement.bk.fixedAlignment": "BALANCED",
-  "org.eclipse.elk.layered.nodePlacement.bk.edgeStraightening": "IMPROVE_STRAIGHTNESS",
-  "org.eclipse.elk.layered.nodePlacement.favorStraightEdges": "true",
-  "org.eclipse.elk.layered.priority.straightness": "10",
-  "org.eclipse.elk.hierarchyHandling": "INCLUDE_CHILDREN",
-  "org.eclipse.elk.layered.crossingMinimization.strategy": "LAYER_SWEEP",
-  "org.eclipse.elk.edgeRouting": "ORTHOGONAL",
-  "org.eclipse.elk.layered.unnecessaryBendpoints": "true",
-  "org.eclipse.elk.layered.cycleBreaking.strategy": "GREEDY_MODEL_ORDER",
-  "org.eclipse.elk.layered.considerModelOrder.crossingCounterNodeInfluence": "0.001",
-  "org.eclipse.elk.layered.spacing.edgeNode": "24",
-  "org.eclipse.elk.layered.spacing.edgeNodeBetweenLayers": "40",
-  "org.eclipse.elk.layered.spacing.nodeNode": "24",
-  "org.eclipse.elk.layered.spacing.nodeNodeBetweenLayers": "80",
-  "org.eclipse.elk.layered.spacing.componentComponent": "70",
-  "org.eclipse.elk.layered.mergeEdges": "true",
+  'org.eclipse.elk.algorithm': 'org.eclipse.elk.layered',
+  'org.eclipse.elk.direction': 'DOWN',
+  'org.eclipse.elk.layered.nodePlacement.strategy': 'BRANDES_KOEPF',
+  'org.eclipse.elk.layered.nodePlacement.bk.fixedAlignment': 'BALANCED',
+  'org.eclipse.elk.layered.nodePlacement.bk.edgeStraightening':
+    'IMPROVE_STRAIGHTNESS',
+  'org.eclipse.elk.layered.nodePlacement.favorStraightEdges': 'true',
+  'org.eclipse.elk.layered.priority.straightness': '10',
+  'org.eclipse.elk.hierarchyHandling': 'INCLUDE_CHILDREN',
+  'org.eclipse.elk.layered.crossingMinimization.strategy': 'LAYER_SWEEP',
+  'org.eclipse.elk.edgeRouting': 'ORTHOGONAL',
+  'org.eclipse.elk.layered.unnecessaryBendpoints': 'true',
+  'org.eclipse.elk.layered.cycleBreaking.strategy': 'GREEDY_MODEL_ORDER',
+  'org.eclipse.elk.layered.considerModelOrder.crossingCounterNodeInfluence':
+    '0.001',
+  'org.eclipse.elk.layered.spacing.edgeNode': '24',
+  'org.eclipse.elk.layered.spacing.edgeNodeBetweenLayers': '40',
+  'org.eclipse.elk.layered.spacing.nodeNode': '24',
+  'org.eclipse.elk.layered.spacing.nodeNodeBetweenLayers': '80',
+  'org.eclipse.elk.layered.spacing.componentComponent': '70',
+  'org.eclipse.elk.layered.mergeEdges': 'true',
 };
 
 export const PARENT_LAYOUT_OPTIONS: LayoutOptions = {
   ...ROOT_LAYOUT_OPTIONS,
-  "org.eclipse.elk.padding": "[top=60,left=20,bottom=20,right=20]",
+  'org.eclipse.elk.padding': '[top=60,left=20,bottom=20,right=20]',
 };
 
 // Helper function to clean up empty edges arrays from nodes
@@ -101,10 +107,12 @@ function findCommonAncestor(
   }
 
   // If no common ancestor found, return "root"
-  return "root";
+  return 'root';
 }
 
-export function buildElkGraphFromReactFlowGraph(reactFlowGraph: ReactFlowGraph): ElkNode {
+export function buildElkGraphFromReactFlowGraph(
+  reactFlowGraph: ReactFlowGraph,
+): ElkNode {
   // Create a map for easy lookup (without width/height initially)
   const nodeMap = new Map<string, ElkNode>(
     reactFlowGraph.nodes.map((node) => [
@@ -145,7 +153,9 @@ export function buildElkGraphFromReactFlowGraph(reactFlowGraph: ReactFlowGraph):
     }
   });
 
-  const reactFlowNodeMap = new Map(reactFlowGraph.nodes.map((node) => [node.id, node]));
+  const reactFlowNodeMap = new Map(
+    reactFlowGraph.nodes.map((node) => [node.id, node]),
+  );
 
   // Nest edges in the appropriate hierarchy level
   const rootEdges: ElkExtendedEdge[] = [];
@@ -157,9 +167,13 @@ export function buildElkGraphFromReactFlowGraph(reactFlowGraph: ReactFlowGraph):
     };
 
     // Find the lowest common ancestor that contains both source and target
-    const commonAncestor = findCommonAncestor(edge.source, edge.target, reactFlowNodeMap);
+    const commonAncestor = findCommonAncestor(
+      edge.source,
+      edge.target,
+      reactFlowNodeMap,
+    );
 
-    if (commonAncestor === "root") {
+    if (commonAncestor === 'root') {
       rootEdges.push(elkEdge);
     } else {
       const ancestorNode = nodeMap.get(commonAncestor);
@@ -176,7 +190,7 @@ export function buildElkGraphFromReactFlowGraph(reactFlowGraph: ReactFlowGraph):
   rootChildren.forEach(cleanupEmptyEdges);
 
   return {
-    id: "root",
+    id: 'root',
     layoutOptions: ROOT_LAYOUT_OPTIONS,
     children: rootChildren,
     edges: rootEdges,
@@ -223,7 +237,7 @@ function isEdgeInsideParent(
   // Edge is inside a parent if the lowest common ancestor is not the root
   // This matches the logic used in findCommonAncestor when building the ELK graph
   const commonAncestor = findCommonAncestor(edge.source, edge.target, nodeMap);
-  return commonAncestor !== "root";
+  return commonAncestor !== 'root';
 }
 
 // set
@@ -237,7 +251,10 @@ export function matchReactFlowGraphWithElkLayoutedGraph(
 
   // Build node map for O(1) lookups in isEdgeInsideParent
   const reactFlowNodeMap = new Map(
-    graph.nodes.map((node) => [node.id, { id: node.id, parentId: node.parentId }]),
+    graph.nodes.map((node) => [
+      node.id,
+      { id: node.id, parentId: node.parentId },
+    ]),
   );
 
   // Map node positions
@@ -260,7 +277,8 @@ export function matchReactFlowGraphWithElkLayoutedGraph(
     if (elkEdge) {
       // Reconstruct data without old wayPoints to avoid stale routing
       const { wayPoints: _oldWayPoints, ...restData } = edge.data || {};
-      const bendPoints = elkEdge.sections?.flatMap((section) => section.bendPoints || []) || [];
+      const bendPoints =
+        elkEdge.sections?.flatMap((section) => section.bendPoints || []) || [];
 
       // Always create new data object, only add wayPoints if there are bend points
       const newData = { ...restData };

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/autoLayout.ts
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/autoLayout.ts
@@ -14,19 +14,26 @@
  * limitations under the License.
  */
 
-import type {
-  ElkNode,
-  LayoutOptions,
-  ElkExtendedEdge,
-} from 'elkjs/lib/elk.bundled.js';
-import { processElkLayout } from '@/core';
-import { ReactFlowGraph } from './diagramBuilder';
+import type { ElkNode, LayoutOptions, ElkExtendedEdge } from "elkjs/lib/elk.bundled.js";
+import { processElkLayout } from "@/core";
+import { ReactFlowGraph } from "./diagramBuilder";
+import { isTerminalNodeType } from "../nodes/taskNodeConfig";
 
 // Defaults
 export const DEFAULT_NODE_SIZE = {
   height: 65,
   width: 220,
 };
+
+// Entry/exit terminals are compact pills, not full task cards
+export const TERMINAL_NODE_SIZE = {
+  height: 30,
+  width: 95,
+};
+
+export function getNodeSize(type: string | undefined): Size {
+  return isTerminalNodeType(type) ? TERMINAL_NODE_SIZE : DEFAULT_NODE_SIZE;
+}
 
 export type Point = {
   x: number;
@@ -43,32 +50,30 @@ export type Size = {
 export type WayPoints = Point[];
 
 export const ROOT_LAYOUT_OPTIONS: LayoutOptions = {
-  'org.eclipse.elk.algorithm': 'org.eclipse.elk.layered',
-  'org.eclipse.elk.direction': 'DOWN',
-  'org.eclipse.elk.layered.nodePlacement.strategy': 'BRANDES_KOEPF',
-  'org.eclipse.elk.layered.nodePlacement.bk.fixedAlignment': 'BALANCED',
-  'org.eclipse.elk.layered.nodePlacement.bk.edgeStraightening':
-    'IMPROVE_STRAIGHTNESS',
-  'org.eclipse.elk.layered.nodePlacement.favorStraightEdges': 'true',
-  'org.eclipse.elk.layered.priority.straightness': '10',
-  'org.eclipse.elk.hierarchyHandling': 'INCLUDE_CHILDREN',
-  'org.eclipse.elk.layered.crossingMinimization.strategy': 'LAYER_SWEEP',
-  'org.eclipse.elk.edgeRouting': 'ORTHOGONAL',
-  'org.eclipse.elk.layered.unnecessaryBendpoints': 'true',
-  'org.eclipse.elk.layered.cycleBreaking.strategy': 'GREEDY_MODEL_ORDER',
-  'org.eclipse.elk.layered.considerModelOrder.crossingCounterNodeInfluence':
-    '0.001',
-  'org.eclipse.elk.layered.spacing.edgeNode': '24',
-  'org.eclipse.elk.layered.spacing.edgeNodeBetweenLayers': '40',
-  'org.eclipse.elk.layered.spacing.nodeNode': '24',
-  'org.eclipse.elk.layered.spacing.nodeNodeBetweenLayers': '80',
-  'org.eclipse.elk.layered.spacing.componentComponent': '70',
-  'org.eclipse.elk.layered.mergeEdges': 'true',
+  "org.eclipse.elk.algorithm": "org.eclipse.elk.layered",
+  "org.eclipse.elk.direction": "DOWN",
+  "org.eclipse.elk.layered.nodePlacement.strategy": "BRANDES_KOEPF",
+  "org.eclipse.elk.layered.nodePlacement.bk.fixedAlignment": "BALANCED",
+  "org.eclipse.elk.layered.nodePlacement.bk.edgeStraightening": "IMPROVE_STRAIGHTNESS",
+  "org.eclipse.elk.layered.nodePlacement.favorStraightEdges": "true",
+  "org.eclipse.elk.layered.priority.straightness": "10",
+  "org.eclipse.elk.hierarchyHandling": "INCLUDE_CHILDREN",
+  "org.eclipse.elk.layered.crossingMinimization.strategy": "LAYER_SWEEP",
+  "org.eclipse.elk.edgeRouting": "ORTHOGONAL",
+  "org.eclipse.elk.layered.unnecessaryBendpoints": "true",
+  "org.eclipse.elk.layered.cycleBreaking.strategy": "GREEDY_MODEL_ORDER",
+  "org.eclipse.elk.layered.considerModelOrder.crossingCounterNodeInfluence": "0.001",
+  "org.eclipse.elk.layered.spacing.edgeNode": "24",
+  "org.eclipse.elk.layered.spacing.edgeNodeBetweenLayers": "40",
+  "org.eclipse.elk.layered.spacing.nodeNode": "24",
+  "org.eclipse.elk.layered.spacing.nodeNodeBetweenLayers": "50",
+  "org.eclipse.elk.layered.spacing.componentComponent": "70",
+  "org.eclipse.elk.layered.mergeEdges": "true",
 };
 
 export const PARENT_LAYOUT_OPTIONS: LayoutOptions = {
   ...ROOT_LAYOUT_OPTIONS,
-  'org.eclipse.elk.padding': '[top=60,left=20,bottom=20,right=20]',
+  "org.eclipse.elk.padding": "[top=60,left=20,bottom=20,right=20]",
 };
 
 // Helper function to clean up empty edges arrays from nodes
@@ -107,12 +112,10 @@ function findCommonAncestor(
   }
 
   // If no common ancestor found, return "root"
-  return 'root';
+  return "root";
 }
 
-export function buildElkGraphFromReactFlowGraph(
-  reactFlowGraph: ReactFlowGraph,
-): ElkNode {
+export function buildElkGraphFromReactFlowGraph(reactFlowGraph: ReactFlowGraph): ElkNode {
   // Create a map for easy lookup (without width/height initially)
   const nodeMap = new Map<string, ElkNode>(
     reactFlowGraph.nodes.map((node) => [
@@ -148,14 +151,13 @@ export function buildElkGraphFromReactFlowGraph(
       elkNode.layoutOptions = { ...PARENT_LAYOUT_OPTIONS };
     } else {
       // Leaf nodes get fixed dimensions
-      elkNode.width = node.measured?.width ?? DEFAULT_NODE_SIZE.width;
-      elkNode.height = node.measured?.height ?? DEFAULT_NODE_SIZE.height;
+      const fallbackSize = getNodeSize(node.type);
+      elkNode.width = node.measured?.width ?? fallbackSize.width;
+      elkNode.height = node.measured?.height ?? fallbackSize.height;
     }
   });
 
-  const reactFlowNodeMap = new Map(
-    reactFlowGraph.nodes.map((node) => [node.id, node]),
-  );
+  const reactFlowNodeMap = new Map(reactFlowGraph.nodes.map((node) => [node.id, node]));
 
   // Nest edges in the appropriate hierarchy level
   const rootEdges: ElkExtendedEdge[] = [];
@@ -167,13 +169,9 @@ export function buildElkGraphFromReactFlowGraph(
     };
 
     // Find the lowest common ancestor that contains both source and target
-    const commonAncestor = findCommonAncestor(
-      edge.source,
-      edge.target,
-      reactFlowNodeMap,
-    );
+    const commonAncestor = findCommonAncestor(edge.source, edge.target, reactFlowNodeMap);
 
-    if (commonAncestor === 'root') {
+    if (commonAncestor === "root") {
       rootEdges.push(elkEdge);
     } else {
       const ancestorNode = nodeMap.get(commonAncestor);
@@ -190,7 +188,7 @@ export function buildElkGraphFromReactFlowGraph(
   rootChildren.forEach(cleanupEmptyEdges);
 
   return {
-    id: 'root',
+    id: "root",
     layoutOptions: ROOT_LAYOUT_OPTIONS,
     children: rootChildren,
     edges: rootEdges,
@@ -237,7 +235,7 @@ function isEdgeInsideParent(
   // Edge is inside a parent if the lowest common ancestor is not the root
   // This matches the logic used in findCommonAncestor when building the ELK graph
   const commonAncestor = findCommonAncestor(edge.source, edge.target, nodeMap);
-  return commonAncestor !== 'root';
+  return commonAncestor !== "root";
 }
 
 // set
@@ -251,10 +249,7 @@ export function matchReactFlowGraphWithElkLayoutedGraph(
 
   // Build node map for O(1) lookups in isEdgeInsideParent
   const reactFlowNodeMap = new Map(
-    graph.nodes.map((node) => [
-      node.id,
-      { id: node.id, parentId: node.parentId },
-    ]),
+    graph.nodes.map((node) => [node.id, { id: node.id, parentId: node.parentId }]),
   );
 
   // Map node positions
@@ -277,8 +272,7 @@ export function matchReactFlowGraphWithElkLayoutedGraph(
     if (elkEdge) {
       // Reconstruct data without old wayPoints to avoid stale routing
       const { wayPoints: _oldWayPoints, ...restData } = edge.data || {};
-      const bendPoints =
-        elkEdge.sections?.flatMap((section) => section.bendPoints || []) || [];
+      const bendPoints = elkEdge.sections?.flatMap((section) => section.bendPoints || []) || [];
 
       // Always create new data object, only add wayPoints if there are bend points
       const newData = { ...restData };

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/diagramBuilder.ts
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/diagramBuilder.ts
@@ -19,8 +19,8 @@ import { buildFlatGraph } from "../../core";
 import { BaseNodeData, ReactFlowNodeTypes } from "../nodes/Nodes";
 import { BaseEdgeData, EdgeTypes } from "../edges/Edges";
 import * as sdk from "@serverlessworkflow/sdk";
-import { DEFAULT_NODE_SIZE } from "./autoLayout";
-import { CATCH_CONTAINER_NODE_TYPE } from "../nodes/taskNodeConfig";
+import { getNodeSize } from "./autoLayout";
+import { CATCH_CONTAINER_NODE_TYPE, isTerminalNodeType } from "../nodes/taskNodeConfig";
 
 export type ReactFlowGraph = {
   nodes: RF.Node[];
@@ -83,17 +83,26 @@ function buildReactFlowNode(
     throw new Error(`Unsupported React flow node type: ${type}!`);
   }
 
+  const size = getNodeSize(type);
+  const isTerminal = isTerminalNodeType(type);
+
   return {
     id: graphNode.id,
     type,
     data: {
       label: graphNode.label ?? "",
-      ...(graphNode.task !== undefined && { task: structuredClone(graphNode.task) }),
+      ...(graphNode.task !== undefined && {
+        task: structuredClone(graphNode.task),
+      }),
     },
-    height: DEFAULT_NODE_SIZE.height,
-    width: DEFAULT_NODE_SIZE.width,
+    height: size.height,
+    width: size.width,
     position: { x: 0, y: 0 },
-    ...(graphNode.parentId !== "root" && { parentId: graphNode.parentId, extent: "parent" }),
+    ...(isTerminal && { selectable: false, draggable: false }),
+    ...(graphNode.parentId !== "root" && {
+      parentId: graphNode.parentId,
+      extent: "parent",
+    }),
   };
 }
 

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/nodes/Nodes.tsx
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/nodes/Nodes.tsx
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-import type React from "react";
-import { GraphNodeType, type Specification } from "@serverlessworkflow/sdk";
-import * as RF from "@xyflow/react";
+import type React from 'react';
+import { GraphNodeType, type Specification } from '@serverlessworkflow/sdk';
+import * as RF from '@xyflow/react';
 import {
   CATCH_CONTAINER_NODE_TYPE,
   type ContainerNodeType,
   type LeafNodeType,
   leafNodeConfigMap,
   containerNodeConfigMap,
-} from "./taskNodeConfig";
-import { getCallSubType, getListenSubType, getRunSubType } from "../../core";
+} from './taskNodeConfig';
+import { getCallSubType, getListenSubType, getRunSubType } from '../../core';
 
 export const ReactFlowNodeTypes: RF.NodeTypes = {
   [GraphNodeType.Start]: StartNode,
@@ -49,21 +49,21 @@ export const ReactFlowNodeTypes: RF.NodeTypes = {
 };
 
 const KNOWN_BADGES = new Set([
-  "http",
-  "grpc",
-  "asyncapi",
-  "openapi",
-  "a2a",
-  "mcp",
-  "container",
-  "script",
-  "shell",
-  "workflow",
-  "all",
-  "any",
-  "one",
-  "compete",
-  "while",
+  'http',
+  'grpc',
+  'asyncapi',
+  'openapi',
+  'a2a',
+  'mcp',
+  'container',
+  'script',
+  'shell',
+  'workflow',
+  'all',
+  'any',
+  'one',
+  'compete',
+  'while',
 ]);
 
 export type BaseNodeData<T = Specification.Task | void> = {
@@ -90,7 +90,11 @@ function TaskNodeBadge({ badge, testId }: BadgeProps) {
   if (isUnknown) {
     /* TODO: instead of using the browser default to display tool tip like below, replace with tooltip component when we add it */
     return (
-      <span title={badge} className="dec-task-node-badge-custom" data-testid={`${testId}-custom`}>
+      <span
+        title={badge}
+        className="dec-task-node-badge-custom"
+        data-testid={`${testId}-custom`}
+      >
         {badge}
       </span>
     );
@@ -103,13 +107,19 @@ function TaskNodeBadge({ badge, testId }: BadgeProps) {
   );
 }
 
-function LeafNodeContent({ id, data, selected, type, badge }: NodeContentProps) {
+function LeafNodeContent({
+  id,
+  data,
+  selected,
+  type,
+  badge,
+}: NodeContentProps) {
   const config = leafNodeConfigMap[type as LeafNodeType];
   const Icon = config.icon;
   return (
     <div
-      className={`dec-leaf-node ${selected ? "selected" : ""}`}
-      style={{ "--task-node-color": config.color } as React.CSSProperties}
+      className={`dec-leaf-node ${selected ? 'selected' : ''}`}
+      style={{ '--task-node-color': config.color } as React.CSSProperties}
       data-testid={`${type}-node-${id}`}
     >
       <RF.Handle type="target" position={RF.Position.Top} />
@@ -119,7 +129,12 @@ function LeafNodeContent({ id, data, selected, type, badge }: NodeContentProps) 
           <span className="dec-leaf-node-name">{data.label}</span>
           <div className="dec-leaf-node-meta">
             <span className="dec-leaf-node-type">{config.typeLabel}</span>
-            {badge && <TaskNodeBadge badge={badge} testId={`${type}-node-${id}-badge`} />}
+            {badge && (
+              <TaskNodeBadge
+                badge={badge}
+                testId={`${type}-node-${id}-badge`}
+              />
+            )}
           </div>
         </div>
       </div>
@@ -128,13 +143,19 @@ function LeafNodeContent({ id, data, selected, type, badge }: NodeContentProps) 
   );
 }
 
-function ContainerNodeContent({ id, data, selected, type, badge }: NodeContentProps) {
+function ContainerNodeContent({
+  id,
+  data,
+  selected,
+  type,
+  badge,
+}: NodeContentProps) {
   const config = containerNodeConfigMap[type as ContainerNodeType];
   const Icon = config.icon;
   return (
     <div
-      className={`dec-container-node ${selected ? "selected" : ""}`}
-      style={{ "--task-node-color": config.color } as React.CSSProperties}
+      className={`dec-container-node ${selected ? 'selected' : ''}`}
+      style={{ '--task-node-color': config.color } as React.CSSProperties}
       data-testid={`${type}-node-${id}`}
     >
       <RF.Handle type="target" position={RF.Position.Top} />
@@ -144,7 +165,9 @@ function ContainerNodeContent({ id, data, selected, type, badge }: NodeContentPr
           <span className="dec-container-node-name">{data.label}</span>
           <span className="dec-container-node-type">{config.typeLabel}</span>
         </div>
-        {badge && <TaskNodeBadge badge={badge} testId={`${type}-node-${id}-badge`} />}
+        {badge && (
+          <TaskNodeBadge badge={badge} testId={`${type}-node-${id}-badge`} />
+        )}
       </div>
       <RF.Handle type="source" position={RF.Position.Bottom} />
     </div>
@@ -163,7 +186,7 @@ interface PlaceholderProps {
 function PlaceholderContent({ id, data, selected, type }: PlaceholderProps) {
   return (
     <div
-      className={`custom-node-container ${selected ? "selected" : ""}`}
+      className={`custom-node-container ${selected ? 'selected' : ''}`}
       data-testid={`${type}-node-${id}`}
     >
       <RF.Handle type="target" position={RF.Position.Top} />
@@ -177,63 +200,154 @@ function PlaceholderContent({ id, data, selected, type }: PlaceholderProps) {
 
 /* start node */
 export type StartNodeType = RF.Node<BaseNodeData, typeof GraphNodeType.Start>;
-export function StartNode({ id, data, selected, type }: RF.NodeProps<StartNodeType>) {
+export function StartNode({
+  id,
+  data,
+  selected,
+  type,
+}: RF.NodeProps<StartNodeType>) {
   // TODO: This component is just a placeholder
-  return <PlaceholderContent id={id} data={data} selected={selected} type={type} />;
+  return (
+    <PlaceholderContent id={id} data={data} selected={selected} type={type} />
+  );
 }
 
 /* end node */
 export type EndNodeType = RF.Node<BaseNodeData, typeof GraphNodeType.End>;
-export function EndNode({ id, data, selected, type }: RF.NodeProps<EndNodeType>) {
+export function EndNode({
+  id,
+  data,
+  selected,
+  type,
+}: RF.NodeProps<EndNodeType>) {
   // TODO: This component is just a placeholder
-  return <PlaceholderContent id={id} data={data} selected={selected} type={type} />;
+  return (
+    <PlaceholderContent id={id} data={data} selected={selected} type={type} />
+  );
 }
 
 /* entry node */
 export type EntryNodeType = RF.Node<BaseNodeData, typeof GraphNodeType.Entry>;
-export function EntryNode({ id, data, selected, type }: RF.NodeProps<EntryNodeType>) {
+export function EntryNode({
+  id,
+  data,
+  selected,
+  type,
+}: RF.NodeProps<EntryNodeType>) {
   // TODO: This component is just a placeholder
-  return <PlaceholderContent id={id} data={data} selected={selected} type={type} />;
+  return (
+    <PlaceholderContent id={id} data={data} selected={selected} type={type} />
+  );
 }
 
 /* exit node */
 export type ExitNodeType = RF.Node<BaseNodeData, typeof GraphNodeType.Exit>;
-export function ExitNode({ id, data, selected, type }: RF.NodeProps<ExitNodeType>) {
+export function ExitNode({
+  id,
+  data,
+  selected,
+  type,
+}: RF.NodeProps<ExitNodeType>) {
   // TODO: This component is just a placeholder
-  return <PlaceholderContent id={id} data={data} selected={selected} type={type} />;
+  return (
+    <PlaceholderContent id={id} data={data} selected={selected} type={type} />
+  );
 }
 
 /* call leaf node */
-export type CallNodeType = RF.Node<BaseNodeData<Specification.CallTask>, typeof GraphNodeType.Call>;
-export function CallNode({ id, data, selected, type }: RF.NodeProps<CallNodeType>) {
+export type CallNodeType = RF.Node<
+  BaseNodeData<Specification.CallTask>,
+  typeof GraphNodeType.Call
+>;
+export function CallNode({
+  id,
+  data,
+  selected,
+  type,
+}: RF.NodeProps<CallNodeType>) {
   const badge = data.task ? getCallSubType(data.task) : undefined;
-  return <LeafNodeContent id={id} data={data} selected={selected} type={type} badge={badge} />;
+  return (
+    <LeafNodeContent
+      id={id}
+      data={data}
+      selected={selected}
+      type={type}
+      badge={badge}
+    />
+  );
 }
 
 /* do container node */
-export type DoNodeType = RF.Node<BaseNodeData<Specification.DoTask>, typeof GraphNodeType.Do>;
+export type DoNodeType = RF.Node<
+  BaseNodeData<Specification.DoTask>,
+  typeof GraphNodeType.Do
+>;
 export function DoNode({ id, data, selected, type }: RF.NodeProps<DoNodeType>) {
-  return <ContainerNodeContent id={id} data={data} selected={selected} type={type} />;
+  return (
+    <ContainerNodeContent id={id} data={data} selected={selected} type={type} />
+  );
 }
 
 /* emit leaf node */
-export type EmitNodeType = RF.Node<BaseNodeData<Specification.EmitTask>, typeof GraphNodeType.Emit>;
-export function EmitNode({ id, data, selected, type }: RF.NodeProps<EmitNodeType>) {
-  return <LeafNodeContent id={id} data={data} selected={selected} type={type} />;
+export type EmitNodeType = RF.Node<
+  BaseNodeData<Specification.EmitTask>,
+  typeof GraphNodeType.Emit
+>;
+export function EmitNode({
+  id,
+  data,
+  selected,
+  type,
+}: RF.NodeProps<EmitNodeType>) {
+  return (
+    <LeafNodeContent id={id} data={data} selected={selected} type={type} />
+  );
 }
 
 /* for container node */
-export type ForNodeType = RF.Node<BaseNodeData<Specification.ForTask>, typeof GraphNodeType.For>;
-export function ForNode({ id, data, selected, type }: RF.NodeProps<ForNodeType>) {
-  const badge = data.task?.while ? "while" : undefined;
-  return <ContainerNodeContent id={id} data={data} selected={selected} type={type} badge={badge} />;
+export type ForNodeType = RF.Node<
+  BaseNodeData<Specification.ForTask>,
+  typeof GraphNodeType.For
+>;
+export function ForNode({
+  id,
+  data,
+  selected,
+  type,
+}: RF.NodeProps<ForNodeType>) {
+  const badge = data.task?.while ? 'while' : undefined;
+  return (
+    <ContainerNodeContent
+      id={id}
+      data={data}
+      selected={selected}
+      type={type}
+      badge={badge}
+    />
+  );
 }
 
 /* fork container node */
-export type ForkNodeType = RF.Node<BaseNodeData<Specification.ForkTask>, typeof GraphNodeType.Fork>;
-export function ForkNode({ id, data, selected, type }: RF.NodeProps<ForkNodeType>) {
-  const badge = data.task?.fork?.compete ? "compete" : undefined;
-  return <ContainerNodeContent id={id} data={data} selected={selected} type={type} badge={badge} />;
+export type ForkNodeType = RF.Node<
+  BaseNodeData<Specification.ForkTask>,
+  typeof GraphNodeType.Fork
+>;
+export function ForkNode({
+  id,
+  data,
+  selected,
+  type,
+}: RF.NodeProps<ForkNodeType>) {
+  const badge = data.task?.fork?.compete ? 'compete' : undefined;
+  return (
+    <ContainerNodeContent
+      id={id}
+      data={data}
+      selected={selected}
+      type={type}
+      badge={badge}
+    />
+  );
 }
 
 /* listen leaf node */
@@ -241,9 +355,22 @@ export type ListenNodeType = RF.Node<
   BaseNodeData<Specification.ListenTask>,
   typeof GraphNodeType.Listen
 >;
-export function ListenNode({ id, data, selected, type }: RF.NodeProps<ListenNodeType>) {
+export function ListenNode({
+  id,
+  data,
+  selected,
+  type,
+}: RF.NodeProps<ListenNodeType>) {
   const badge = data.task ? getListenSubType(data.task) : undefined;
-  return <LeafNodeContent id={id} data={data} selected={selected} type={type} badge={badge} />;
+  return (
+    <LeafNodeContent
+      id={id}
+      data={data}
+      selected={selected}
+      type={type}
+      badge={badge}
+    />
+  );
 }
 
 /* raise leaf node */
@@ -251,21 +378,54 @@ export type RaiseNodeType = RF.Node<
   BaseNodeData<Specification.RaiseTask>,
   typeof GraphNodeType.Raise
 >;
-export function RaiseNode({ id, data, selected, type }: RF.NodeProps<RaiseNodeType>) {
-  return <LeafNodeContent id={id} data={data} selected={selected} type={type} />;
+export function RaiseNode({
+  id,
+  data,
+  selected,
+  type,
+}: RF.NodeProps<RaiseNodeType>) {
+  return (
+    <LeafNodeContent id={id} data={data} selected={selected} type={type} />
+  );
 }
 
 /* run leaf node */
-export type RunNodeType = RF.Node<BaseNodeData<Specification.RunTask>, typeof GraphNodeType.Run>;
-export function RunNode({ id, data, selected, type }: RF.NodeProps<RunNodeType>) {
+export type RunNodeType = RF.Node<
+  BaseNodeData<Specification.RunTask>,
+  typeof GraphNodeType.Run
+>;
+export function RunNode({
+  id,
+  data,
+  selected,
+  type,
+}: RF.NodeProps<RunNodeType>) {
   const badge = data.task ? getRunSubType(data.task) : undefined;
-  return <LeafNodeContent id={id} data={data} selected={selected} type={type} badge={badge} />;
+  return (
+    <LeafNodeContent
+      id={id}
+      data={data}
+      selected={selected}
+      type={type}
+      badge={badge}
+    />
+  );
 }
 
 /* set leaf node */
-export type SetNodeType = RF.Node<BaseNodeData<Specification.SetTask>, typeof GraphNodeType.Set>;
-export function SetNode({ id, data, selected, type }: RF.NodeProps<SetNodeType>) {
-  return <LeafNodeContent id={id} data={data} selected={selected} type={type} />;
+export type SetNodeType = RF.Node<
+  BaseNodeData<Specification.SetTask>,
+  typeof GraphNodeType.Set
+>;
+export function SetNode({
+  id,
+  data,
+  selected,
+  type,
+}: RF.NodeProps<SetNodeType>) {
+  return (
+    <LeafNodeContent id={id} data={data} selected={selected} type={type} />
+  );
 }
 
 /* switch leaf node */
@@ -273,41 +433,90 @@ export type SwitchNodeType = RF.Node<
   BaseNodeData<Specification.SwitchTask>,
   typeof GraphNodeType.Switch
 >;
-export function SwitchNode({ id, data, selected, type }: RF.NodeProps<SwitchNodeType>) {
-  return <LeafNodeContent id={id} data={data} selected={selected} type={type} />;
+export function SwitchNode({
+  id,
+  data,
+  selected,
+  type,
+}: RF.NodeProps<SwitchNodeType>) {
+  return (
+    <LeafNodeContent id={id} data={data} selected={selected} type={type} />
+  );
 }
 
 /* try catch container node */
-export type TryCatchNodeType = RF.Node<BaseNodeData, typeof GraphNodeType.TryCatch>;
-export function TryCatchNode({ id, data, selected, type }: RF.NodeProps<TryCatchNodeType>) {
-  return <ContainerNodeContent id={id} data={data} selected={selected} type={type} />;
+export type TryCatchNodeType = RF.Node<
+  BaseNodeData,
+  typeof GraphNodeType.TryCatch
+>;
+export function TryCatchNode({
+  id,
+  data,
+  selected,
+  type,
+}: RF.NodeProps<TryCatchNodeType>) {
+  return (
+    <ContainerNodeContent id={id} data={data} selected={selected} type={type} />
+  );
 }
 
 /* try container node */
-export type TryNodeType = RF.Node<BaseNodeData<Specification.TryTask>, typeof GraphNodeType.Try>;
-export function TryNode({ id, data, selected, type }: RF.NodeProps<TryNodeType>) {
-  return <ContainerNodeContent id={id} data={data} selected={selected} type={type} />;
+export type TryNodeType = RF.Node<
+  BaseNodeData<Specification.TryTask>,
+  typeof GraphNodeType.Try
+>;
+export function TryNode({
+  id,
+  data,
+  selected,
+  type,
+}: RF.NodeProps<TryNodeType>) {
+  return (
+    <ContainerNodeContent id={id} data={data} selected={selected} type={type} />
+  );
 }
 
 /* catch leaf node */
 export type CatchNodeType = RF.Node<BaseNodeData, typeof GraphNodeType.Catch>;
-export function CatchNode({ id, data, selected, type }: RF.NodeProps<CatchNodeType>) {
-  return <LeafNodeContent id={id} data={data} selected={selected} type={type} />;
+export function CatchNode({
+  id,
+  data,
+  selected,
+  type,
+}: RF.NodeProps<CatchNodeType>) {
+  return (
+    <LeafNodeContent id={id} data={data} selected={selected} type={type} />
+  );
 }
 
 /* catch container node */
-export type CatchContainerNodeType = RF.Node<BaseNodeData, typeof CATCH_CONTAINER_NODE_TYPE>;
+export type CatchContainerNodeType = RF.Node<
+  BaseNodeData,
+  typeof CATCH_CONTAINER_NODE_TYPE
+>;
 export function CatchContainerNode({
   id,
   data,
   selected,
   type,
 }: RF.NodeProps<CatchContainerNodeType>) {
-  return <ContainerNodeContent id={id} data={data} selected={selected} type={type} />;
+  return (
+    <ContainerNodeContent id={id} data={data} selected={selected} type={type} />
+  );
 }
 
 /* wait leaf node */
-export type WaitNodeType = RF.Node<BaseNodeData<Specification.WaitTask>, typeof GraphNodeType.Wait>;
-export function WaitNode({ id, data, selected, type }: RF.NodeProps<WaitNodeType>) {
-  return <LeafNodeContent id={id} data={data} selected={selected} type={type} />;
+export type WaitNodeType = RF.Node<
+  BaseNodeData<Specification.WaitTask>,
+  typeof GraphNodeType.Wait
+>;
+export function WaitNode({
+  id,
+  data,
+  selected,
+  type,
+}: RF.NodeProps<WaitNodeType>) {
+  return (
+    <LeafNodeContent id={id} data={data} selected={selected} type={type} />
+  );
 }

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/nodes/Nodes.tsx
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/nodes/Nodes.tsx
@@ -14,17 +14,20 @@
  * limitations under the License.
  */
 
-import type React from 'react';
-import { GraphNodeType, type Specification } from '@serverlessworkflow/sdk';
-import * as RF from '@xyflow/react';
+import type React from "react";
+import { GraphNodeType, type Specification } from "@serverlessworkflow/sdk";
+import * as RF from "@xyflow/react";
+import { useI18n } from "@serverlessworkflow/i18n";
 import {
   CATCH_CONTAINER_NODE_TYPE,
   type ContainerNodeType,
   type LeafNodeType,
+  type TerminalNodeType,
   leafNodeConfigMap,
   containerNodeConfigMap,
-} from './taskNodeConfig';
-import { getCallSubType, getListenSubType, getRunSubType } from '../../core';
+  terminalNodeConfigMap,
+} from "./taskNodeConfig";
+import { getCallSubType, getListenSubType, getRunSubType } from "../../core";
 
 export const ReactFlowNodeTypes: RF.NodeTypes = {
   [GraphNodeType.Start]: StartNode,
@@ -49,21 +52,21 @@ export const ReactFlowNodeTypes: RF.NodeTypes = {
 };
 
 const KNOWN_BADGES = new Set([
-  'http',
-  'grpc',
-  'asyncapi',
-  'openapi',
-  'a2a',
-  'mcp',
-  'container',
-  'script',
-  'shell',
-  'workflow',
-  'all',
-  'any',
-  'one',
-  'compete',
-  'while',
+  "http",
+  "grpc",
+  "asyncapi",
+  "openapi",
+  "a2a",
+  "mcp",
+  "container",
+  "script",
+  "shell",
+  "workflow",
+  "all",
+  "any",
+  "one",
+  "compete",
+  "while",
 ]);
 
 export type BaseNodeData<T = Specification.Task | void> = {
@@ -90,11 +93,7 @@ function TaskNodeBadge({ badge, testId }: BadgeProps) {
   if (isUnknown) {
     /* TODO: instead of using the browser default to display tool tip like below, replace with tooltip component when we add it */
     return (
-      <span
-        title={badge}
-        className="dec-task-node-badge-custom"
-        data-testid={`${testId}-custom`}
-      >
+      <span title={badge} className="dec-task-node-badge-custom" data-testid={`${testId}-custom`}>
         {badge}
       </span>
     );
@@ -107,19 +106,13 @@ function TaskNodeBadge({ badge, testId }: BadgeProps) {
   );
 }
 
-function LeafNodeContent({
-  id,
-  data,
-  selected,
-  type,
-  badge,
-}: NodeContentProps) {
+function LeafNodeContent({ id, data, selected, type, badge }: NodeContentProps) {
   const config = leafNodeConfigMap[type as LeafNodeType];
   const Icon = config.icon;
   return (
     <div
-      className={`dec-leaf-node ${selected ? 'selected' : ''}`}
-      style={{ '--task-node-color': config.color } as React.CSSProperties}
+      className={`dec-leaf-node ${selected ? "selected" : ""}`}
+      style={{ "--task-node-color": config.color } as React.CSSProperties}
       data-testid={`${type}-node-${id}`}
     >
       <RF.Handle type="target" position={RF.Position.Top} />
@@ -129,12 +122,7 @@ function LeafNodeContent({
           <span className="dec-leaf-node-name">{data.label}</span>
           <div className="dec-leaf-node-meta">
             <span className="dec-leaf-node-type">{config.typeLabel}</span>
-            {badge && (
-              <TaskNodeBadge
-                badge={badge}
-                testId={`${type}-node-${id}-badge`}
-              />
-            )}
+            {badge && <TaskNodeBadge badge={badge} testId={`${type}-node-${id}-badge`} />}
           </div>
         </div>
       </div>
@@ -143,19 +131,13 @@ function LeafNodeContent({
   );
 }
 
-function ContainerNodeContent({
-  id,
-  data,
-  selected,
-  type,
-  badge,
-}: NodeContentProps) {
+function ContainerNodeContent({ id, data, selected, type, badge }: NodeContentProps) {
   const config = containerNodeConfigMap[type as ContainerNodeType];
   const Icon = config.icon;
   return (
     <div
-      className={`dec-container-node ${selected ? 'selected' : ''}`}
-      style={{ '--task-node-color': config.color } as React.CSSProperties}
+      className={`dec-container-node ${selected ? "selected" : ""}`}
+      style={{ "--task-node-color": config.color } as React.CSSProperties}
       data-testid={`${type}-node-${id}`}
     >
       <RF.Handle type="target" position={RF.Position.Top} />
@@ -165,11 +147,29 @@ function ContainerNodeContent({
           <span className="dec-container-node-name">{data.label}</span>
           <span className="dec-container-node-type">{config.typeLabel}</span>
         </div>
-        {badge && (
-          <TaskNodeBadge badge={badge} testId={`${type}-node-${id}-badge`} />
-        )}
+        {badge && <TaskNodeBadge badge={badge} testId={`${type}-node-${id}-badge`} />}
       </div>
       <RF.Handle type="source" position={RF.Position.Bottom} />
+    </div>
+  );
+}
+
+/* Entry/exit nodes */
+function TerminalNodeContent({ id, type }: { id: string; type: TerminalNodeType }) {
+  const { t } = useI18n();
+  const config = terminalNodeConfigMap[type];
+  const Icon = config.icon;
+  const label = t(config.labelKey);
+  const isEntry = type === GraphNodeType.Entry;
+  return (
+    <div className="dec-terminal-node" data-testid={`${type}-node-${id}`}>
+      {isEntry ? (
+        <RF.Handle type="source" position={RF.Position.Bottom} />
+      ) : (
+        <RF.Handle type="target" position={RF.Position.Top} />
+      )}
+      <Icon size={14} className="dec-terminal-node-icon" />
+      <span className="dec-terminal-node-label">{label}</span>
     </div>
   );
 }
@@ -186,7 +186,7 @@ interface PlaceholderProps {
 function PlaceholderContent({ id, data, selected, type }: PlaceholderProps) {
   return (
     <div
-      className={`custom-node-container ${selected ? 'selected' : ''}`}
+      className={`custom-node-container ${selected ? "selected" : ""}`}
       data-testid={`${type}-node-${id}`}
     >
       <RF.Handle type="target" position={RF.Position.Top} />
@@ -200,154 +200,61 @@ function PlaceholderContent({ id, data, selected, type }: PlaceholderProps) {
 
 /* start node */
 export type StartNodeType = RF.Node<BaseNodeData, typeof GraphNodeType.Start>;
-export function StartNode({
-  id,
-  data,
-  selected,
-  type,
-}: RF.NodeProps<StartNodeType>) {
+export function StartNode({ id, data, selected, type }: RF.NodeProps<StartNodeType>) {
   // TODO: This component is just a placeholder
-  return (
-    <PlaceholderContent id={id} data={data} selected={selected} type={type} />
-  );
+  return <PlaceholderContent id={id} data={data} selected={selected} type={type} />;
 }
 
 /* end node */
 export type EndNodeType = RF.Node<BaseNodeData, typeof GraphNodeType.End>;
-export function EndNode({
-  id,
-  data,
-  selected,
-  type,
-}: RF.NodeProps<EndNodeType>) {
+export function EndNode({ id, data, selected, type }: RF.NodeProps<EndNodeType>) {
   // TODO: This component is just a placeholder
-  return (
-    <PlaceholderContent id={id} data={data} selected={selected} type={type} />
-  );
+  return <PlaceholderContent id={id} data={data} selected={selected} type={type} />;
 }
 
 /* entry node */
 export type EntryNodeType = RF.Node<BaseNodeData, typeof GraphNodeType.Entry>;
-export function EntryNode({
-  id,
-  data,
-  selected,
-  type,
-}: RF.NodeProps<EntryNodeType>) {
-  // TODO: This component is just a placeholder
-  return (
-    <PlaceholderContent id={id} data={data} selected={selected} type={type} />
-  );
+export function EntryNode({ id, type }: RF.NodeProps<EntryNodeType>) {
+  return <TerminalNodeContent id={id} type={type} />;
 }
 
 /* exit node */
 export type ExitNodeType = RF.Node<BaseNodeData, typeof GraphNodeType.Exit>;
-export function ExitNode({
-  id,
-  data,
-  selected,
-  type,
-}: RF.NodeProps<ExitNodeType>) {
-  // TODO: This component is just a placeholder
-  return (
-    <PlaceholderContent id={id} data={data} selected={selected} type={type} />
-  );
+export function ExitNode({ id, type }: RF.NodeProps<ExitNodeType>) {
+  return <TerminalNodeContent id={id} type={type} />;
 }
 
 /* call leaf node */
-export type CallNodeType = RF.Node<
-  BaseNodeData<Specification.CallTask>,
-  typeof GraphNodeType.Call
->;
-export function CallNode({
-  id,
-  data,
-  selected,
-  type,
-}: RF.NodeProps<CallNodeType>) {
+export type CallNodeType = RF.Node<BaseNodeData<Specification.CallTask>, typeof GraphNodeType.Call>;
+export function CallNode({ id, data, selected, type }: RF.NodeProps<CallNodeType>) {
   const badge = data.task ? getCallSubType(data.task) : undefined;
-  return (
-    <LeafNodeContent
-      id={id}
-      data={data}
-      selected={selected}
-      type={type}
-      badge={badge}
-    />
-  );
+  return <LeafNodeContent id={id} data={data} selected={selected} type={type} badge={badge} />;
 }
 
 /* do container node */
-export type DoNodeType = RF.Node<
-  BaseNodeData<Specification.DoTask>,
-  typeof GraphNodeType.Do
->;
+export type DoNodeType = RF.Node<BaseNodeData<Specification.DoTask>, typeof GraphNodeType.Do>;
 export function DoNode({ id, data, selected, type }: RF.NodeProps<DoNodeType>) {
-  return (
-    <ContainerNodeContent id={id} data={data} selected={selected} type={type} />
-  );
+  return <ContainerNodeContent id={id} data={data} selected={selected} type={type} />;
 }
 
 /* emit leaf node */
-export type EmitNodeType = RF.Node<
-  BaseNodeData<Specification.EmitTask>,
-  typeof GraphNodeType.Emit
->;
-export function EmitNode({
-  id,
-  data,
-  selected,
-  type,
-}: RF.NodeProps<EmitNodeType>) {
-  return (
-    <LeafNodeContent id={id} data={data} selected={selected} type={type} />
-  );
+export type EmitNodeType = RF.Node<BaseNodeData<Specification.EmitTask>, typeof GraphNodeType.Emit>;
+export function EmitNode({ id, data, selected, type }: RF.NodeProps<EmitNodeType>) {
+  return <LeafNodeContent id={id} data={data} selected={selected} type={type} />;
 }
 
 /* for container node */
-export type ForNodeType = RF.Node<
-  BaseNodeData<Specification.ForTask>,
-  typeof GraphNodeType.For
->;
-export function ForNode({
-  id,
-  data,
-  selected,
-  type,
-}: RF.NodeProps<ForNodeType>) {
-  const badge = data.task?.while ? 'while' : undefined;
-  return (
-    <ContainerNodeContent
-      id={id}
-      data={data}
-      selected={selected}
-      type={type}
-      badge={badge}
-    />
-  );
+export type ForNodeType = RF.Node<BaseNodeData<Specification.ForTask>, typeof GraphNodeType.For>;
+export function ForNode({ id, data, selected, type }: RF.NodeProps<ForNodeType>) {
+  const badge = data.task?.while ? "while" : undefined;
+  return <ContainerNodeContent id={id} data={data} selected={selected} type={type} badge={badge} />;
 }
 
 /* fork container node */
-export type ForkNodeType = RF.Node<
-  BaseNodeData<Specification.ForkTask>,
-  typeof GraphNodeType.Fork
->;
-export function ForkNode({
-  id,
-  data,
-  selected,
-  type,
-}: RF.NodeProps<ForkNodeType>) {
-  const badge = data.task?.fork?.compete ? 'compete' : undefined;
-  return (
-    <ContainerNodeContent
-      id={id}
-      data={data}
-      selected={selected}
-      type={type}
-      badge={badge}
-    />
-  );
+export type ForkNodeType = RF.Node<BaseNodeData<Specification.ForkTask>, typeof GraphNodeType.Fork>;
+export function ForkNode({ id, data, selected, type }: RF.NodeProps<ForkNodeType>) {
+  const badge = data.task?.fork?.compete ? "compete" : undefined;
+  return <ContainerNodeContent id={id} data={data} selected={selected} type={type} badge={badge} />;
 }
 
 /* listen leaf node */
@@ -355,22 +262,9 @@ export type ListenNodeType = RF.Node<
   BaseNodeData<Specification.ListenTask>,
   typeof GraphNodeType.Listen
 >;
-export function ListenNode({
-  id,
-  data,
-  selected,
-  type,
-}: RF.NodeProps<ListenNodeType>) {
+export function ListenNode({ id, data, selected, type }: RF.NodeProps<ListenNodeType>) {
   const badge = data.task ? getListenSubType(data.task) : undefined;
-  return (
-    <LeafNodeContent
-      id={id}
-      data={data}
-      selected={selected}
-      type={type}
-      badge={badge}
-    />
-  );
+  return <LeafNodeContent id={id} data={data} selected={selected} type={type} badge={badge} />;
 }
 
 /* raise leaf node */
@@ -378,54 +272,21 @@ export type RaiseNodeType = RF.Node<
   BaseNodeData<Specification.RaiseTask>,
   typeof GraphNodeType.Raise
 >;
-export function RaiseNode({
-  id,
-  data,
-  selected,
-  type,
-}: RF.NodeProps<RaiseNodeType>) {
-  return (
-    <LeafNodeContent id={id} data={data} selected={selected} type={type} />
-  );
+export function RaiseNode({ id, data, selected, type }: RF.NodeProps<RaiseNodeType>) {
+  return <LeafNodeContent id={id} data={data} selected={selected} type={type} />;
 }
 
 /* run leaf node */
-export type RunNodeType = RF.Node<
-  BaseNodeData<Specification.RunTask>,
-  typeof GraphNodeType.Run
->;
-export function RunNode({
-  id,
-  data,
-  selected,
-  type,
-}: RF.NodeProps<RunNodeType>) {
+export type RunNodeType = RF.Node<BaseNodeData<Specification.RunTask>, typeof GraphNodeType.Run>;
+export function RunNode({ id, data, selected, type }: RF.NodeProps<RunNodeType>) {
   const badge = data.task ? getRunSubType(data.task) : undefined;
-  return (
-    <LeafNodeContent
-      id={id}
-      data={data}
-      selected={selected}
-      type={type}
-      badge={badge}
-    />
-  );
+  return <LeafNodeContent id={id} data={data} selected={selected} type={type} badge={badge} />;
 }
 
 /* set leaf node */
-export type SetNodeType = RF.Node<
-  BaseNodeData<Specification.SetTask>,
-  typeof GraphNodeType.Set
->;
-export function SetNode({
-  id,
-  data,
-  selected,
-  type,
-}: RF.NodeProps<SetNodeType>) {
-  return (
-    <LeafNodeContent id={id} data={data} selected={selected} type={type} />
-  );
+export type SetNodeType = RF.Node<BaseNodeData<Specification.SetTask>, typeof GraphNodeType.Set>;
+export function SetNode({ id, data, selected, type }: RF.NodeProps<SetNodeType>) {
+  return <LeafNodeContent id={id} data={data} selected={selected} type={type} />;
 }
 
 /* switch leaf node */
@@ -433,90 +294,41 @@ export type SwitchNodeType = RF.Node<
   BaseNodeData<Specification.SwitchTask>,
   typeof GraphNodeType.Switch
 >;
-export function SwitchNode({
-  id,
-  data,
-  selected,
-  type,
-}: RF.NodeProps<SwitchNodeType>) {
-  return (
-    <LeafNodeContent id={id} data={data} selected={selected} type={type} />
-  );
+export function SwitchNode({ id, data, selected, type }: RF.NodeProps<SwitchNodeType>) {
+  return <LeafNodeContent id={id} data={data} selected={selected} type={type} />;
 }
 
 /* try catch container node */
-export type TryCatchNodeType = RF.Node<
-  BaseNodeData,
-  typeof GraphNodeType.TryCatch
->;
-export function TryCatchNode({
-  id,
-  data,
-  selected,
-  type,
-}: RF.NodeProps<TryCatchNodeType>) {
-  return (
-    <ContainerNodeContent id={id} data={data} selected={selected} type={type} />
-  );
+export type TryCatchNodeType = RF.Node<BaseNodeData, typeof GraphNodeType.TryCatch>;
+export function TryCatchNode({ id, data, selected, type }: RF.NodeProps<TryCatchNodeType>) {
+  return <ContainerNodeContent id={id} data={data} selected={selected} type={type} />;
 }
 
 /* try container node */
-export type TryNodeType = RF.Node<
-  BaseNodeData<Specification.TryTask>,
-  typeof GraphNodeType.Try
->;
-export function TryNode({
-  id,
-  data,
-  selected,
-  type,
-}: RF.NodeProps<TryNodeType>) {
-  return (
-    <ContainerNodeContent id={id} data={data} selected={selected} type={type} />
-  );
+export type TryNodeType = RF.Node<BaseNodeData<Specification.TryTask>, typeof GraphNodeType.Try>;
+export function TryNode({ id, data, selected, type }: RF.NodeProps<TryNodeType>) {
+  return <ContainerNodeContent id={id} data={data} selected={selected} type={type} />;
 }
 
 /* catch leaf node */
 export type CatchNodeType = RF.Node<BaseNodeData, typeof GraphNodeType.Catch>;
-export function CatchNode({
-  id,
-  data,
-  selected,
-  type,
-}: RF.NodeProps<CatchNodeType>) {
-  return (
-    <LeafNodeContent id={id} data={data} selected={selected} type={type} />
-  );
+export function CatchNode({ id, data, selected, type }: RF.NodeProps<CatchNodeType>) {
+  return <LeafNodeContent id={id} data={data} selected={selected} type={type} />;
 }
 
 /* catch container node */
-export type CatchContainerNodeType = RF.Node<
-  BaseNodeData,
-  typeof CATCH_CONTAINER_NODE_TYPE
->;
+export type CatchContainerNodeType = RF.Node<BaseNodeData, typeof CATCH_CONTAINER_NODE_TYPE>;
 export function CatchContainerNode({
   id,
   data,
   selected,
   type,
 }: RF.NodeProps<CatchContainerNodeType>) {
-  return (
-    <ContainerNodeContent id={id} data={data} selected={selected} type={type} />
-  );
+  return <ContainerNodeContent id={id} data={data} selected={selected} type={type} />;
 }
 
 /* wait leaf node */
-export type WaitNodeType = RF.Node<
-  BaseNodeData<Specification.WaitTask>,
-  typeof GraphNodeType.Wait
->;
-export function WaitNode({
-  id,
-  data,
-  selected,
-  type,
-}: RF.NodeProps<WaitNodeType>) {
-  return (
-    <LeafNodeContent id={id} data={data} selected={selected} type={type} />
-  );
+export type WaitNodeType = RF.Node<BaseNodeData<Specification.WaitTask>, typeof GraphNodeType.Wait>;
+export function WaitNode({ id, data, selected, type }: RF.NodeProps<WaitNodeType>) {
+  return <LeafNodeContent id={id} data={data} selected={selected} type={type} />;
 }

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/nodes/taskNodeConfig.ts
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/nodes/taskNodeConfig.ts
@@ -24,6 +24,8 @@ import {
   GitFork,
   IterationCw,
   List,
+  LogIn,
+  LogOut,
   Megaphone,
   PenLine,
   Phone,
@@ -31,6 +33,7 @@ import {
   Terminal,
 } from "lucide-react";
 import type { ComponentType } from "react";
+import type { TranslationKeys } from "../../i18n/locales/en";
 
 export interface TaskNodeConfig {
   color: string;
@@ -38,8 +41,15 @@ export interface TaskNodeConfig {
   typeLabel: string;
 }
 
+export interface TerminalNodeConfig {
+  icon: ComponentType<{ size?: number; className?: string }>;
+  labelKey: TranslationKeys;
+}
+
 /* Custom react-flow only node type for catch nodes that contain child nodes (i.e are containers) (the sdk uses GraphNodeType.Catch for both leaf and container catch nodes) */
 export const CATCH_CONTAINER_NODE_TYPE = "catch-container";
+
+export type TerminalNodeType = typeof GraphNodeType.Entry | typeof GraphNodeType.Exit;
 
 export type ContainerNodeType =
   | typeof GraphNodeType.Do
@@ -140,6 +150,21 @@ export const containerNodeConfigMap: Record<ContainerNodeType, TaskNodeConfig> =
     typeLabel: "CATCH",
   },
 };
+
+export const terminalNodeConfigMap: Record<TerminalNodeType, TerminalNodeConfig> = {
+  [GraphNodeType.Entry]: {
+    icon: LogIn,
+    labelKey: "node.entry",
+  },
+  [GraphNodeType.Exit]: {
+    icon: LogOut,
+    labelKey: "node.exit",
+  },
+};
+
+export function isTerminalNodeType(type: string | undefined): type is TerminalNodeType {
+  return type === GraphNodeType.Entry || type === GraphNodeType.Exit;
+}
 
 const nodeConfigMap: Record<string, TaskNodeConfig> = {
   ...leafNodeConfigMap,

--- a/packages/serverless-workflow-diagram-editor/tests/react-flow/diagram/autoLayout.integration.test.ts
+++ b/packages/serverless-workflow-diagram-editor/tests/react-flow/diagram/autoLayout.integration.test.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import type { ElkNode } from "elkjs/lib/elk.bundled.js";
-import type { Node, Edge } from "@xyflow/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ElkNode } from 'elkjs/lib/elk.bundled.js';
+import type { Node, Edge } from '@xyflow/react';
 import {
   buildElkGraphFromReactFlowGraph,
   matchReactFlowGraphWithElkLayoutedGraph,
@@ -24,98 +24,100 @@ import {
   DEFAULT_NODE_SIZE,
   ROOT_LAYOUT_OPTIONS,
   PARENT_LAYOUT_OPTIONS,
-} from "../../../src/react-flow/diagram/autoLayout";
-import type { ReactFlowGraph } from "../../../src/react-flow/diagram/diagramBuilder";
-import * as core from "../../../src/core";
+} from '../../../src/react-flow/diagram/autoLayout';
+import type { ReactFlowGraph } from '../../../src/react-flow/diagram/diagramBuilder';
+import * as core from '../../../src/core';
 
 // Mock the processElkLayout function
-vi.mock("../../../src/core", () => ({
+vi.mock('../../../src/core', () => ({
   processElkLayout: vi.fn(),
 }));
 
-describe("autoLayout", () => {
-  describe("buildElkGraphFromReactFlowGraph", () => {
-    it("converts simple ReactFlow graph to ELK graph", () => {
+describe('autoLayout', () => {
+  describe('buildElkGraphFromReactFlowGraph', () => {
+    it('converts simple ReactFlow graph to ELK graph', () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
           {
-            id: "node1",
+            id: 'node1',
             position: { x: 0, y: 0 },
             data: {},
             measured: { width: 150, height: 50 },
           },
           {
-            id: "node2",
+            id: 'node2',
             position: { x: 0, y: 0 },
             data: {},
             measured: { width: 200, height: 60 },
           },
         ] as Node[],
-        edges: [{ id: "edge1", source: "node1", target: "node2", data: {} }] as Edge[],
+        edges: [
+          { id: 'edge1', source: 'node1', target: 'node2', data: {} },
+        ] as Edge[],
       };
 
       const elkGraph = buildElkGraphFromReactFlowGraph(reactFlowGraph);
 
-      expect(elkGraph.id).toBe("root");
+      expect(elkGraph.id).toBe('root');
       expect(elkGraph.layoutOptions).toEqual(ROOT_LAYOUT_OPTIONS);
       expect(elkGraph.children).toHaveLength(2);
       expect(elkGraph.children?.[0]).toEqual({
-        id: "node1",
+        id: 'node1',
         width: 150,
         height: 50,
         children: [],
       });
       expect(elkGraph.children?.[1]).toEqual({
-        id: "node2",
+        id: 'node2',
         width: 200,
         height: 60,
         children: [],
       });
       expect(elkGraph.edges).toHaveLength(1);
       expect(elkGraph.edges?.[0]).toEqual({
-        id: "edge1",
-        sources: ["node1"],
-        targets: ["node2"],
+        id: 'edge1',
+        sources: ['node1'],
+        targets: ['node2'],
       });
     });
 
-    it("uses default node size when measured dimensions are not available", () => {
+    it('uses default node size when measured dimensions are not available', () => {
       const reactFlowGraph: ReactFlowGraph = {
-        nodes: [{ id: "node1", position: { x: 0, y: 0 }, data: {} }] as Node[],
+        nodes: [{ id: 'node1', position: { x: 0, y: 0 }, data: {} }] as Node[],
         edges: [],
       };
 
       const elkGraph = buildElkGraphFromReactFlowGraph(reactFlowGraph);
 
       expect(elkGraph.children?.[0]).toEqual({
-        id: "node1",
+        id: 'node1',
         width: DEFAULT_NODE_SIZE.width,
         height: DEFAULT_NODE_SIZE.height,
         children: [],
       });
     });
 
-    it("handles nested nodes with parentId", () => {
+    it('handles nested nodes with parentId', () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
           {
-            id: "parent",
+            id: 'parent',
             position: { x: 0, y: 0 },
             data: {},
             measured: { width: 300, height: 200 },
           },
           {
-            id: "child1",
+            id: 'child1',
             position: { x: 10, y: 10 },
             data: {},
-            parentId: "parent",
+            parentId: 'parent',
             measured: { width: 100, height: 50 },
           },
           {
-            id: "child2",
+            id: 'child2',
             position: { x: 10, y: 70 },
             data: {},
-            parentId: "parent",
+            parentId: 'parent',
             measured: { width: 100, height: 50 },
           },
         ] as Node[],
@@ -125,13 +127,13 @@ describe("autoLayout", () => {
       const elkGraph = buildElkGraphFromReactFlowGraph(reactFlowGraph);
 
       expect(elkGraph.children).toHaveLength(1);
-      expect(elkGraph.children?.[0].id).toBe("parent");
+      expect(elkGraph.children?.[0].id).toBe('parent');
       expect(elkGraph.children?.[0].children).toHaveLength(2);
-      expect(elkGraph.children?.[0].children?.[0].id).toBe("child1");
-      expect(elkGraph.children?.[0].children?.[1].id).toBe("child2");
+      expect(elkGraph.children?.[0].children?.[0].id).toBe('child1');
+      expect(elkGraph.children?.[0].children?.[1].id).toBe('child2');
     });
 
-    it("handles empty graph", () => {
+    it('handles empty graph', () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [],
         edges: [],
@@ -139,20 +141,20 @@ describe("autoLayout", () => {
 
       const elkGraph = buildElkGraphFromReactFlowGraph(reactFlowGraph);
 
-      expect(elkGraph.id).toBe("root");
+      expect(elkGraph.id).toBe('root');
       expect(elkGraph.children).toHaveLength(0);
       expect(elkGraph.edges).toHaveLength(0);
     });
 
-    it("handles multiple edges between nodes", () => {
+    it('handles multiple edges between nodes', () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
-          { id: "node1", position: { x: 0, y: 0 }, data: {} },
-          { id: "node2", position: { x: 0, y: 0 }, data: {} },
+          { id: 'node1', position: { x: 0, y: 0 }, data: {} },
+          { id: 'node2', position: { x: 0, y: 0 }, data: {} },
         ] as Node[],
         edges: [
-          { id: "edge1", source: "node1", target: "node2", data: {} },
-          { id: "edge2", source: "node2", target: "node1", data: {} },
+          { id: 'edge1', source: 'node1', target: 'node2', data: {} },
+          { id: 'edge2', source: 'node2', target: 'node1', data: {} },
         ] as Edge[],
       };
 
@@ -160,25 +162,25 @@ describe("autoLayout", () => {
 
       expect(elkGraph.edges).toHaveLength(2);
       expect(elkGraph.edges?.[0]).toEqual({
-        id: "edge1",
-        sources: ["node1"],
-        targets: ["node2"],
+        id: 'edge1',
+        sources: ['node1'],
+        targets: ['node2'],
       });
       expect(elkGraph.edges?.[1]).toEqual({
-        id: "edge2",
-        sources: ["node2"],
-        targets: ["node1"],
+        id: 'edge2',
+        sources: ['node2'],
+        targets: ['node1'],
       });
     });
 
-    it("treat as a root-level if parentId is non-existent", () => {
+    it('treat as a root-level if parentId is non-existent', () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
           {
-            id: "node1",
+            id: 'node1',
             position: { x: 0, y: 0 },
             data: {},
-            parentId: "nonexistent",
+            parentId: 'nonexistent',
           },
         ] as Node[],
         edges: [],
@@ -187,23 +189,23 @@ describe("autoLayout", () => {
       const elkGraph = buildElkGraphFromReactFlowGraph(reactFlowGraph);
 
       expect(elkGraph.children).toHaveLength(1);
-      expect(elkGraph.children?.[0].id).toBe("node1");
+      expect(elkGraph.children?.[0].id).toBe('node1');
     });
 
-    it("applies PARENT_LAYOUT_OPTIONS to nodes with children", () => {
+    it('applies PARENT_LAYOUT_OPTIONS to nodes with children', () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
           {
-            id: "parent",
+            id: 'parent',
             position: { x: 0, y: 0 },
             data: {},
             measured: { width: 300, height: 200 },
           },
           {
-            id: "child",
+            id: 'child',
             position: { x: 10, y: 10 },
             data: {},
-            parentId: "parent",
+            parentId: 'parent',
             measured: { width: 100, height: 50 },
           },
         ] as Node[],
@@ -214,41 +216,57 @@ describe("autoLayout", () => {
 
       // Parent node should have layout options and no fixed dimensions
       expect(elkGraph.children?.[0].layoutOptions).toBeDefined();
-      expect(elkGraph.children?.[0].layoutOptions?.["org.eclipse.elk.padding"]).toBe(
-        "[top=60,left=20,bottom=20,right=20]",
-      );
+      expect(
+        elkGraph.children?.[0].layoutOptions?.['org.eclipse.elk.padding'],
+      ).toBe('[top=60,left=20,bottom=20,right=20]');
       expect(elkGraph.children?.[0].width).toBeUndefined();
       expect(elkGraph.children?.[0].height).toBeUndefined();
 
       // Child node should have fixed dimensions and no layout options
       expect(elkGraph.children?.[0].children?.[0].width).toBe(100);
       expect(elkGraph.children?.[0].children?.[0].height).toBe(50);
-      expect(elkGraph.children?.[0].children?.[0].layoutOptions).toBeUndefined();
+      expect(
+        elkGraph.children?.[0].children?.[0].layoutOptions,
+      ).toBeUndefined();
     });
 
-    it("places edges at correct hierarchy level - root level", () => {
+    it('places edges at correct hierarchy level - root level', () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
-          { id: "node1", position: { x: 0, y: 0 }, data: {} },
-          { id: "node2", position: { x: 0, y: 0 }, data: {} },
+          { id: 'node1', position: { x: 0, y: 0 }, data: {} },
+          { id: 'node2', position: { x: 0, y: 0 }, data: {} },
         ] as Node[],
-        edges: [{ id: "edge1", source: "node1", target: "node2", data: {} }] as Edge[],
+        edges: [
+          { id: 'edge1', source: 'node1', target: 'node2', data: {} },
+        ] as Edge[],
       };
 
       const elkGraph = buildElkGraphFromReactFlowGraph(reactFlowGraph);
 
       expect(elkGraph.edges).toHaveLength(1);
-      expect(elkGraph.edges?.[0].id).toBe("edge1");
+      expect(elkGraph.edges?.[0].id).toBe('edge1');
     });
 
-    it("places edges at correct hierarchy level - inside parent", () => {
+    it('places edges at correct hierarchy level - inside parent', () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
-          { id: "parent", position: { x: 0, y: 0 }, data: {} },
-          { id: "child1", position: { x: 0, y: 0 }, data: {}, parentId: "parent" },
-          { id: "child2", position: { x: 0, y: 0 }, data: {}, parentId: "parent" },
+          { id: 'parent', position: { x: 0, y: 0 }, data: {} },
+          {
+            id: 'child1',
+            position: { x: 0, y: 0 },
+            data: {},
+            parentId: 'parent',
+          },
+          {
+            id: 'child2',
+            position: { x: 0, y: 0 },
+            data: {},
+            parentId: 'parent',
+          },
         ] as Node[],
-        edges: [{ id: "edge1", source: "child1", target: "child2", data: {} }] as Edge[],
+        edges: [
+          { id: 'edge1', source: 'child1', target: 'child2', data: {} },
+        ] as Edge[],
       };
 
       const elkGraph = buildElkGraphFromReactFlowGraph(reactFlowGraph);
@@ -256,18 +274,30 @@ describe("autoLayout", () => {
       // Edge should be inside parent, not at root
       expect(elkGraph.edges).toHaveLength(0);
       expect(elkGraph.children?.[0].edges).toHaveLength(1);
-      expect(elkGraph.children?.[0].edges?.[0].id).toBe("edge1");
+      expect(elkGraph.children?.[0].edges?.[0].id).toBe('edge1');
     });
 
-    it("places edges at lowest common ancestor", () => {
+    it('places edges at lowest common ancestor', () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
-          { id: "parent1", position: { x: 0, y: 0 }, data: {} },
-          { id: "child1", position: { x: 0, y: 0 }, data: {}, parentId: "parent1" },
-          { id: "parent2", position: { x: 0, y: 0 }, data: {} },
-          { id: "child2", position: { x: 0, y: 0 }, data: {}, parentId: "parent2" },
+          { id: 'parent1', position: { x: 0, y: 0 }, data: {} },
+          {
+            id: 'child1',
+            position: { x: 0, y: 0 },
+            data: {},
+            parentId: 'parent1',
+          },
+          { id: 'parent2', position: { x: 0, y: 0 }, data: {} },
+          {
+            id: 'child2',
+            position: { x: 0, y: 0 },
+            data: {},
+            parentId: 'parent2',
+          },
         ] as Node[],
-        edges: [{ id: "edge1", source: "child1", target: "child2", data: {} }] as Edge[],
+        edges: [
+          { id: 'edge1', source: 'child1', target: 'child2', data: {} },
+        ] as Edge[],
       };
 
       const elkGraph = buildElkGraphFromReactFlowGraph(reactFlowGraph);
@@ -278,11 +308,16 @@ describe("autoLayout", () => {
       expect(elkGraph.children?.[1].edges).toBeUndefined();
     });
 
-    it("cleans up empty edges arrays", () => {
+    it('cleans up empty edges arrays', () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
-          { id: "parent", position: { x: 0, y: 0 }, data: {} },
-          { id: "child", position: { x: 0, y: 0 }, data: {}, parentId: "parent" },
+          { id: 'parent', position: { x: 0, y: 0 }, data: {} },
+          {
+            id: 'child',
+            position: { x: 0, y: 0 },
+            data: {},
+            parentId: 'parent',
+          },
         ] as Node[],
         edges: [],
       };
@@ -294,15 +329,32 @@ describe("autoLayout", () => {
       expect(elkGraph.children?.[0].children?.[0].edges).toBeUndefined();
     });
 
-    it("handles multi-level nesting with edges at different levels", () => {
+    it('handles multi-level nesting with edges at different levels', () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
-          { id: "grandparent", position: { x: 0, y: 0 }, data: {} },
-          { id: "parent", position: { x: 0, y: 0 }, data: {}, parentId: "grandparent" },
-          { id: "child1", position: { x: 0, y: 0 }, data: {}, parentId: "parent" },
-          { id: "child2", position: { x: 0, y: 0 }, data: {}, parentId: "parent" },
+          { id: 'grandparent', position: { x: 0, y: 0 }, data: {} },
+          {
+            id: 'parent',
+            position: { x: 0, y: 0 },
+            data: {},
+            parentId: 'grandparent',
+          },
+          {
+            id: 'child1',
+            position: { x: 0, y: 0 },
+            data: {},
+            parentId: 'parent',
+          },
+          {
+            id: 'child2',
+            position: { x: 0, y: 0 },
+            data: {},
+            parentId: 'parent',
+          },
         ] as Node[],
-        edges: [{ id: "edge1", source: "child1", target: "child2", data: {} }] as Edge[],
+        edges: [
+          { id: 'edge1', source: 'child1', target: 'child2', data: {} },
+        ] as Edge[],
       };
 
       const elkGraph = buildElkGraphFromReactFlowGraph(reactFlowGraph);
@@ -314,26 +366,29 @@ describe("autoLayout", () => {
     });
   });
 
-  describe("matchReactFlowGraphWithElkLayoutedGraph", () => {
-    it("updates node positions from ELK layout", () => {
+  describe('matchReactFlowGraphWithElkLayoutedGraph', () => {
+    it('updates node positions from ELK layout', () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
-          { id: "node1", position: { x: 0, y: 0 }, data: {} },
-          { id: "node2", position: { x: 0, y: 0 }, data: {} },
+          { id: 'node1', position: { x: 0, y: 0 }, data: {} },
+          { id: 'node2', position: { x: 0, y: 0 }, data: {} },
         ] as Node[],
         edges: [],
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: "root",
+        id: 'root',
         children: [
-          { id: "node1", x: 50, y: 100, width: 200, height: 60 },
-          { id: "node2", x: 50, y: 200, width: 200, height: 60 },
+          { id: 'node1', x: 50, y: 100, width: 200, height: 60 },
+          { id: 'node2', x: 50, y: 200, width: 200, height: 60 },
         ],
         edges: [],
       };
 
-      const result = matchReactFlowGraphWithElkLayoutedGraph(reactFlowGraph, layoutedElkGraph);
+      const result = matchReactFlowGraphWithElkLayoutedGraph(
+        reactFlowGraph,
+        layoutedElkGraph,
+      );
 
       expect(result.nodes[0].position).toEqual({ x: 50, y: 100 });
       expect(result.nodes[0].width).toBe(200);
@@ -341,47 +396,54 @@ describe("autoLayout", () => {
       expect(result.nodes[1].position).toEqual({ x: 50, y: 200 });
     });
 
-    it("preserves original node data when no ELK node found", () => {
+    it('preserves original node data when no ELK node found', () => {
       const reactFlowGraph: ReactFlowGraph = {
-        nodes: [{ id: "node1", position: { x: 10, y: 20 }, data: { label: "Test" } }] as Node[],
+        nodes: [
+          { id: 'node1', position: { x: 10, y: 20 }, data: { label: 'Test' } },
+        ] as Node[],
         edges: [],
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: "root",
+        id: 'root',
         children: [],
         edges: [],
       };
 
-      const result = matchReactFlowGraphWithElkLayoutedGraph(reactFlowGraph, layoutedElkGraph);
+      const result = matchReactFlowGraphWithElkLayoutedGraph(
+        reactFlowGraph,
+        layoutedElkGraph,
+      );
 
       expect(result.nodes[0].position).toEqual({ x: 10, y: 20 });
-      expect(result.nodes[0].data).toEqual({ label: "Test" });
+      expect(result.nodes[0].data).toEqual({ label: 'Test' });
     });
 
-    it("adds waypoints to edges from ELK bend points", () => {
+    it('adds waypoints to edges from ELK bend points', () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
-          { id: "node1", position: { x: 0, y: 0 }, data: {} },
-          { id: "node2", position: { x: 0, y: 0 }, data: {} },
+          { id: 'node1', position: { x: 0, y: 0 }, data: {} },
+          { id: 'node2', position: { x: 0, y: 0 }, data: {} },
         ] as Node[],
-        edges: [{ id: "edge1", source: "node1", target: "node2", data: {} }] as Edge[],
+        edges: [
+          { id: 'edge1', source: 'node1', target: 'node2', data: {} },
+        ] as Edge[],
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: "root",
+        id: 'root',
         children: [
-          { id: "node1", x: 0, y: 0 },
-          { id: "node2", x: 200, y: 100 },
+          { id: 'node1', x: 0, y: 0 },
+          { id: 'node2', x: 200, y: 100 },
         ],
         edges: [
           {
-            id: "edge1",
-            sources: ["node1"],
-            targets: ["node2"],
+            id: 'edge1',
+            sources: ['node1'],
+            targets: ['node2'],
             sections: [
               {
-                id: "section1",
+                id: 'section1',
                 startPoint: { x: 0, y: 0 },
                 endPoint: { x: 200, y: 100 },
                 bendPoints: [
@@ -394,7 +456,10 @@ describe("autoLayout", () => {
         ],
       };
 
-      const result = matchReactFlowGraphWithElkLayoutedGraph(reactFlowGraph, layoutedElkGraph);
+      const result = matchReactFlowGraphWithElkLayoutedGraph(
+        reactFlowGraph,
+        layoutedElkGraph,
+      );
 
       expect(result.edges[0].data?.wayPoints).toEqual([
         { x: 100, y: 0 },
@@ -402,29 +467,31 @@ describe("autoLayout", () => {
       ]);
     });
 
-    it("handles edges without bend points", () => {
+    it('handles edges without bend points', () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
-          { id: "node1", position: { x: 0, y: 0 }, data: {} },
-          { id: "node2", position: { x: 0, y: 0 }, data: {} },
+          { id: 'node1', position: { x: 0, y: 0 }, data: {} },
+          { id: 'node2', position: { x: 0, y: 0 }, data: {} },
         ] as Node[],
-        edges: [{ id: "edge1", source: "node1", target: "node2", data: {} }] as Edge[],
+        edges: [
+          { id: 'edge1', source: 'node1', target: 'node2', data: {} },
+        ] as Edge[],
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: "root",
+        id: 'root',
         children: [
-          { id: "node1", x: 0, y: 0 },
-          { id: "node2", x: 200, y: 0 },
+          { id: 'node1', x: 0, y: 0 },
+          { id: 'node2', x: 200, y: 0 },
         ],
         edges: [
           {
-            id: "edge1",
-            sources: ["node1"],
-            targets: ["node2"],
+            id: 'edge1',
+            sources: ['node1'],
+            targets: ['node2'],
             sections: [
               {
-                id: "section1",
+                id: 'section1',
                 startPoint: { x: 0, y: 0 },
                 endPoint: { x: 200, y: 0 },
               },
@@ -433,66 +500,72 @@ describe("autoLayout", () => {
         ],
       };
 
-      const result = matchReactFlowGraphWithElkLayoutedGraph(reactFlowGraph, layoutedElkGraph);
+      const result = matchReactFlowGraphWithElkLayoutedGraph(
+        reactFlowGraph,
+        layoutedElkGraph,
+      );
 
       expect(result.edges[0].data?.wayPoints).toBeUndefined();
     });
 
-    it("clears stale wayPoints when ELK edge has no sections", () => {
+    it('clears stale wayPoints when ELK edge has no sections', () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [],
         edges: [
           {
-            id: "edge1",
-            source: "node1",
-            target: "node2",
-            data: { label: "Test Edge", wayPoints: [{ x: 10, y: 20 }] },
+            id: 'edge1',
+            source: 'node1',
+            target: 'node2',
+            data: { label: 'Test Edge', wayPoints: [{ x: 10, y: 20 }] },
           },
         ] as Edge[],
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: "root",
+        id: 'root',
         children: [],
         edges: [
           {
-            id: "edge1",
-            sources: ["node1"],
-            targets: ["node2"],
+            id: 'edge1',
+            sources: ['node1'],
+            targets: ['node2'],
           },
         ],
       };
 
-      const result = matchReactFlowGraphWithElkLayoutedGraph(reactFlowGraph, layoutedElkGraph);
+      const result = matchReactFlowGraphWithElkLayoutedGraph(
+        reactFlowGraph,
+        layoutedElkGraph,
+      );
 
-      expect(result.edges[0].data).toEqual({ label: "Test Edge" });
+      expect(result.edges[0].data).toEqual({ label: 'Test Edge' });
       expect(result.edges[0].data?.wayPoints).toBeUndefined();
     });
 
-    it("clears stale wayPoints when ELK edge sections have no bend points", () => {
+    it('clears stale wayPoints when ELK edge sections have no bend points', () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [],
         edges: [
           {
-            id: "edge1",
-            source: "node1",
-            target: "node2",
-            data: { label: "Test Edge", wayPoints: [{ x: 10, y: 20 }] },
+            id: 'edge1',
+            source: 'node1',
+            target: 'node2',
+            data: { label: 'Test Edge', wayPoints: [{ x: 10, y: 20 }] },
           },
         ] as Edge[],
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: "root",
+        id: 'root',
         children: [],
         edges: [
           {
-            id: "edge1",
-            sources: ["node1"],
-            targets: ["node2"],
+            id: 'edge1',
+            sources: ['node1'],
+            targets: ['node2'],
             sections: [
               {
-                id: "section1",
+                id: 'section1',
                 startPoint: { x: 0, y: 0 },
                 endPoint: { x: 200, y: 0 },
               },
@@ -501,47 +574,53 @@ describe("autoLayout", () => {
         ],
       };
 
-      const result = matchReactFlowGraphWithElkLayoutedGraph(reactFlowGraph, layoutedElkGraph);
+      const result = matchReactFlowGraphWithElkLayoutedGraph(
+        reactFlowGraph,
+        layoutedElkGraph,
+      );
 
-      expect(result.edges[0].data).toEqual({ label: "Test Edge" });
+      expect(result.edges[0].data).toEqual({ label: 'Test Edge' });
       expect(result.edges[0].data?.wayPoints).toBeUndefined();
     });
 
-    it("preserves edge data when no ELK edge found", () => {
+    it('preserves edge data when no ELK edge found', () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [],
         edges: [
           {
-            id: "edge1",
-            source: "node1",
-            target: "node2",
-            data: { label: "Test Edge" },
+            id: 'edge1',
+            source: 'node1',
+            target: 'node2',
+            data: { label: 'Test Edge' },
           },
         ] as Edge[],
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: "root",
+        id: 'root',
         children: [],
         edges: [],
       };
 
-      const result = matchReactFlowGraphWithElkLayoutedGraph(reactFlowGraph, layoutedElkGraph);
+      const result = matchReactFlowGraphWithElkLayoutedGraph(
+        reactFlowGraph,
+        layoutedElkGraph,
+      );
 
-      expect(result.edges[0].data).toEqual({ label: "Test Edge" });
+      expect(result.edges[0].data).toEqual({ label: 'Test Edge' });
     });
 
-    it("does not mutate original graph", () => {
+    it('does not mutate original graph', () => {
       const reactFlowGraph: ReactFlowGraph = {
-        nodes: [{ id: "node1", position: { x: 0, y: 0 }, data: {} }] as Node[],
+        nodes: [{ id: 'node1', position: { x: 0, y: 0 }, data: {} }] as Node[],
         edges: [],
       };
 
       const originalPosition = { ...reactFlowGraph.nodes[0].position };
 
       const layoutedElkGraph: ElkNode = {
-        id: "root",
-        children: [{ id: "node1", x: 100, y: 200 }],
+        id: 'root',
+        children: [{ id: 'node1', x: 100, y: 200 }],
         edges: [],
       };
 
@@ -550,29 +629,31 @@ describe("autoLayout", () => {
       expect(reactFlowGraph.nodes[0].position).toEqual(originalPosition);
     });
 
-    it("handles multiple sections with bend points", () => {
+    it('handles multiple sections with bend points', () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [],
-        edges: [{ id: "edge1", source: "node1", target: "node2", data: {} }] as Edge[],
+        edges: [
+          { id: 'edge1', source: 'node1', target: 'node2', data: {} },
+        ] as Edge[],
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: "root",
+        id: 'root',
         children: [],
         edges: [
           {
-            id: "edge1",
-            sources: ["node1"],
-            targets: ["node2"],
+            id: 'edge1',
+            sources: ['node1'],
+            targets: ['node2'],
             sections: [
               {
-                id: "section1",
+                id: 'section1',
                 startPoint: { x: 0, y: 0 },
                 endPoint: { x: 100, y: 50 },
                 bendPoints: [{ x: 50, y: 0 }],
               },
               {
-                id: "section2",
+                id: 'section2',
                 startPoint: { x: 100, y: 50 },
                 endPoint: { x: 200, y: 100 },
                 bendPoints: [{ x: 150, y: 100 }],
@@ -582,7 +663,10 @@ describe("autoLayout", () => {
         ],
       };
 
-      const result = matchReactFlowGraphWithElkLayoutedGraph(reactFlowGraph, layoutedElkGraph);
+      const result = matchReactFlowGraphWithElkLayoutedGraph(
+        reactFlowGraph,
+        layoutedElkGraph,
+      );
 
       expect(result.edges[0].data?.wayPoints).toEqual([
         { x: 50, y: 0 },
@@ -590,35 +674,47 @@ describe("autoLayout", () => {
       ]);
     });
 
-    it("handles edges inside parent nodes - removes wayPoints", () => {
+    it('handles edges inside parent nodes - removes wayPoints', () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
-          { id: "parent", position: { x: 0, y: 0 }, data: {} },
-          { id: "child1", position: { x: 0, y: 0 }, data: {}, parentId: "parent" },
-          { id: "child2", position: { x: 0, y: 0 }, data: {}, parentId: "parent" },
+          { id: 'parent', position: { x: 0, y: 0 }, data: {} },
+          {
+            id: 'child1',
+            position: { x: 0, y: 0 },
+            data: {},
+            parentId: 'parent',
+          },
+          {
+            id: 'child2',
+            position: { x: 0, y: 0 },
+            data: {},
+            parentId: 'parent',
+          },
         ] as Node[],
-        edges: [{ id: "edge1", source: "child1", target: "child2", data: {} }] as Edge[],
+        edges: [
+          { id: 'edge1', source: 'child1', target: 'child2', data: {} },
+        ] as Edge[],
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: "root",
+        id: 'root',
         children: [
           {
-            id: "parent",
+            id: 'parent',
             x: 0,
             y: 0,
             children: [
-              { id: "child1", x: 10, y: 10 },
-              { id: "child2", x: 10, y: 70 },
+              { id: 'child1', x: 10, y: 10 },
+              { id: 'child2', x: 10, y: 70 },
             ],
             edges: [
               {
-                id: "edge1",
-                sources: ["child1"],
-                targets: ["child2"],
+                id: 'edge1',
+                sources: ['child1'],
+                targets: ['child2'],
                 sections: [
                   {
-                    id: "section1",
+                    id: 'section1',
                     startPoint: { x: 10, y: 10 },
                     endPoint: { x: 10, y: 70 },
                     bendPoints: [{ x: 10, y: 40 }],
@@ -631,47 +727,62 @@ describe("autoLayout", () => {
         edges: [],
       };
 
-      const result = matchReactFlowGraphWithElkLayoutedGraph(reactFlowGraph, layoutedElkGraph);
+      const result = matchReactFlowGraphWithElkLayoutedGraph(
+        reactFlowGraph,
+        layoutedElkGraph,
+      );
 
       // wayPoints should be undefined for edges inside parent nodes
       expect(result.edges[0].data?.wayPoints).toBeUndefined();
     });
 
-    it("preserves wayPoints for edges not inside parent nodes", () => {
+    it('preserves wayPoints for edges not inside parent nodes', () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
-          { id: "parent1", position: { x: 0, y: 0 }, data: {} },
-          { id: "child1", position: { x: 0, y: 0 }, data: {}, parentId: "parent1" },
-          { id: "parent2", position: { x: 0, y: 0 }, data: {} },
-          { id: "child2", position: { x: 0, y: 0 }, data: {}, parentId: "parent2" },
+          { id: 'parent1', position: { x: 0, y: 0 }, data: {} },
+          {
+            id: 'child1',
+            position: { x: 0, y: 0 },
+            data: {},
+            parentId: 'parent1',
+          },
+          { id: 'parent2', position: { x: 0, y: 0 }, data: {} },
+          {
+            id: 'child2',
+            position: { x: 0, y: 0 },
+            data: {},
+            parentId: 'parent2',
+          },
         ] as Node[],
-        edges: [{ id: "edge1", source: "child1", target: "child2", data: {} }] as Edge[],
+        edges: [
+          { id: 'edge1', source: 'child1', target: 'child2', data: {} },
+        ] as Edge[],
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: "root",
+        id: 'root',
         children: [
           {
-            id: "parent1",
+            id: 'parent1',
             x: 0,
             y: 0,
-            children: [{ id: "child1", x: 10, y: 10 }],
+            children: [{ id: 'child1', x: 10, y: 10 }],
           },
           {
-            id: "parent2",
+            id: 'parent2',
             x: 200,
             y: 0,
-            children: [{ id: "child2", x: 10, y: 10 }],
+            children: [{ id: 'child2', x: 10, y: 10 }],
           },
         ],
         edges: [
           {
-            id: "edge1",
-            sources: ["child1"],
-            targets: ["child2"],
+            id: 'edge1',
+            sources: ['child1'],
+            targets: ['child2'],
             sections: [
               {
-                id: "section1",
+                id: 'section1',
                 startPoint: { x: 10, y: 10 },
                 endPoint: { x: 210, y: 10 },
                 bendPoints: [{ x: 100, y: 10 }],
@@ -681,42 +792,45 @@ describe("autoLayout", () => {
         ],
       };
 
-      const result = matchReactFlowGraphWithElkLayoutedGraph(reactFlowGraph, layoutedElkGraph);
+      const result = matchReactFlowGraphWithElkLayoutedGraph(
+        reactFlowGraph,
+        layoutedElkGraph,
+      );
 
       // wayPoints should be preserved for edges crossing parent boundaries
       expect(result.edges[0].data?.wayPoints).toEqual([{ x: 100, y: 10 }]);
     });
 
-    it("preserves other edge data when updating wayPoints", () => {
+    it('preserves other edge data when updating wayPoints', () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
-          { id: "node1", position: { x: 0, y: 0 }, data: {} },
-          { id: "node2", position: { x: 0, y: 0 }, data: {} },
+          { id: 'node1', position: { x: 0, y: 0 }, data: {} },
+          { id: 'node2', position: { x: 0, y: 0 }, data: {} },
         ] as Node[],
         edges: [
           {
-            id: "edge1",
-            source: "node1",
-            target: "node2",
-            data: { label: "Test", color: "blue", customProp: 123 },
+            id: 'edge1',
+            source: 'node1',
+            target: 'node2',
+            data: { label: 'Test', color: 'blue', customProp: 123 },
           },
         ] as Edge[],
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: "root",
+        id: 'root',
         children: [
-          { id: "node1", x: 0, y: 0 },
-          { id: "node2", x: 200, y: 100 },
+          { id: 'node1', x: 0, y: 0 },
+          { id: 'node2', x: 200, y: 100 },
         ],
         edges: [
           {
-            id: "edge1",
-            sources: ["node1"],
-            targets: ["node2"],
+            id: 'edge1',
+            sources: ['node1'],
+            targets: ['node2'],
             sections: [
               {
-                id: "section1",
+                id: 'section1',
                 startPoint: { x: 0, y: 0 },
                 endPoint: { x: 200, y: 100 },
                 bendPoints: [{ x: 100, y: 50 }],
@@ -726,18 +840,21 @@ describe("autoLayout", () => {
         ],
       };
 
-      const result = matchReactFlowGraphWithElkLayoutedGraph(reactFlowGraph, layoutedElkGraph);
+      const result = matchReactFlowGraphWithElkLayoutedGraph(
+        reactFlowGraph,
+        layoutedElkGraph,
+      );
 
       expect(result.edges[0].data).toEqual({
-        label: "Test",
-        color: "blue",
+        label: 'Test',
+        color: 'blue',
         customProp: 123,
         wayPoints: [{ x: 100, y: 50 }],
       });
     });
   });
 
-  describe("applyAutoLayout", () => {
+  describe('applyAutoLayout', () => {
     beforeEach(() => {
       vi.clearAllMocks();
     });
@@ -746,36 +863,38 @@ describe("autoLayout", () => {
       vi.restoreAllMocks();
     });
 
-    it("applies auto layout successfully", async () => {
+    it('applies auto layout successfully', async () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
           {
-            id: "node1",
+            id: 'node1',
             position: { x: 0, y: 0 },
             data: {},
             measured: { width: 200, height: 60 },
           },
           {
-            id: "node2",
+            id: 'node2',
             position: { x: 0, y: 0 },
             data: {},
             measured: { width: 200, height: 60 },
           },
         ] as Node[],
-        edges: [{ id: "edge1", source: "node1", target: "node2", data: {} }] as Edge[],
+        edges: [
+          { id: 'edge1', source: 'node1', target: 'node2', data: {} },
+        ] as Edge[],
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: "root",
+        id: 'root',
         children: [
-          { id: "node1", x: 50, y: 100, width: 200, height: 60 },
-          { id: "node2", x: 50, y: 200, width: 200, height: 60 },
+          { id: 'node1', x: 50, y: 100, width: 200, height: 60 },
+          { id: 'node2', x: 50, y: 200, width: 200, height: 60 },
         ],
         edges: [
           {
-            id: "edge1",
-            sources: ["node1"],
-            targets: ["node2"],
+            id: 'edge1',
+            sources: ['node1'],
+            targets: ['node2'],
           },
         ],
       };
@@ -789,9 +908,11 @@ describe("autoLayout", () => {
       expect(result.nodes[1].position).toEqual({ x: 50, y: 200 });
     });
 
-    it("returns original graph when ELK layout fails", async () => {
+    it('returns original graph when ELK layout fails', async () => {
       const reactFlowGraph: ReactFlowGraph = {
-        nodes: [{ id: "node1", position: { x: 10, y: 20 }, data: {} }] as Node[],
+        nodes: [
+          { id: 'node1', position: { x: 10, y: 20 }, data: {} },
+        ] as Node[],
         edges: [],
       };
 
@@ -803,14 +924,14 @@ describe("autoLayout", () => {
       expect(result.nodes[0].position).toEqual({ x: 10, y: 20 });
     });
 
-    it("handles empty graph", async () => {
+    it('handles empty graph', async () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [],
         edges: [],
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: "root",
+        id: 'root',
         children: [],
         edges: [],
       };
@@ -823,11 +944,11 @@ describe("autoLayout", () => {
       expect(result.edges).toHaveLength(0);
     });
 
-    it("passes correct ELK graph structure to processElkLayout", async () => {
+    it('passes correct ELK graph structure to processElkLayout', async () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
           {
-            id: "node1",
+            id: 'node1',
             position: { x: 0, y: 0 },
             data: {},
             measured: { width: 150, height: 50 },
@@ -837,8 +958,8 @@ describe("autoLayout", () => {
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: "root",
-        children: [{ id: "node1", x: 0, y: 0 }],
+        id: 'root',
+        children: [{ id: 'node1', x: 0, y: 0 }],
         edges: [],
       };
 
@@ -848,11 +969,11 @@ describe("autoLayout", () => {
 
       expect(core.processElkLayout).toHaveBeenCalledWith(
         {
-          id: "root",
+          id: 'root',
           layoutOptions: ROOT_LAYOUT_OPTIONS,
           children: [
             {
-              id: "node1",
+              id: 'node1',
               width: 150,
               height: 50,
               children: [],
@@ -864,50 +985,52 @@ describe("autoLayout", () => {
       );
     });
 
-    it("handles complex graph with nested nodes and edges", async () => {
+    it('handles complex graph with nested nodes and edges', async () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
           {
-            id: "parent",
+            id: 'parent',
             position: { x: 0, y: 0 },
             data: {},
             measured: { width: 300, height: 200 },
           },
           {
-            id: "child1",
+            id: 'child1',
             position: { x: 10, y: 10 },
             data: {},
-            parentId: "parent",
+            parentId: 'parent',
             measured: { width: 100, height: 50 },
           },
           {
-            id: "node2",
+            id: 'node2',
             position: { x: 0, y: 0 },
             data: {},
             measured: { width: 200, height: 60 },
           },
         ] as Node[],
-        edges: [{ id: "edge1", source: "parent", target: "node2", data: {} }] as Edge[],
+        edges: [
+          { id: 'edge1', source: 'parent', target: 'node2', data: {} },
+        ] as Edge[],
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: "root",
+        id: 'root',
         children: [
           {
-            id: "parent",
+            id: 'parent',
             x: 0,
             y: 0,
             width: 300,
             height: 200,
-            children: [{ id: "child1", x: 10, y: 10, width: 100, height: 50 }],
+            children: [{ id: 'child1', x: 10, y: 10, width: 100, height: 50 }],
           },
-          { id: "node2", x: 350, y: 50, width: 200, height: 60 },
+          { id: 'node2', x: 350, y: 50, width: 200, height: 60 },
         ],
         edges: [
           {
-            id: "edge1",
-            sources: ["parent"],
-            targets: ["node2"],
+            id: 'edge1',
+            sources: ['parent'],
+            targets: ['node2'],
           },
         ],
       };
@@ -921,15 +1044,15 @@ describe("autoLayout", () => {
       expect(result.nodes[2].position).toEqual({ x: 350, y: 50 });
     });
 
-    it("passes abort signal to processElkLayout", async () => {
+    it('passes abort signal to processElkLayout', async () => {
       const reactFlowGraph: ReactFlowGraph = {
-        nodes: [{ id: "node1", position: { x: 0, y: 0 }, data: {} }] as Node[],
+        nodes: [{ id: 'node1', position: { x: 0, y: 0 }, data: {} }] as Node[],
         edges: [],
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: "root",
-        children: [{ id: "node1", x: 50, y: 100 }],
+        id: 'root',
+        children: [{ id: 'node1', x: 50, y: 100 }],
         edges: [],
       };
 
@@ -944,57 +1067,66 @@ describe("autoLayout", () => {
       );
     });
 
-    it("handles processElkLayout rejection gracefully", async () => {
+    it('handles processElkLayout rejection gracefully', async () => {
       const reactFlowGraph: ReactFlowGraph = {
-        nodes: [{ id: "node1", position: { x: 10, y: 20 }, data: {} }] as Node[],
+        nodes: [
+          { id: 'node1', position: { x: 10, y: 20 }, data: {} },
+        ] as Node[],
         edges: [],
       };
 
-      vi.mocked(core.processElkLayout).mockRejectedValue(new Error("Layout failed"));
+      vi.mocked(core.processElkLayout).mockRejectedValue(
+        new Error('Layout failed'),
+      );
 
-      await expect(applyAutoLayout(reactFlowGraph)).rejects.toThrow("Layout failed");
+      await expect(applyAutoLayout(reactFlowGraph)).rejects.toThrow(
+        'Layout failed',
+      );
     });
 
-    describe("buildElkNodeMap helper", () => {
-      it("handles nested nodes correctly in matchReactFlowGraphWithElkLayoutedGraph", () => {
+    describe('buildElkNodeMap helper', () => {
+      it('handles nested nodes correctly in matchReactFlowGraphWithElkLayoutedGraph', () => {
         const reactFlowGraph: ReactFlowGraph = {
           nodes: [
-            { id: "parent", position: { x: 0, y: 0 }, data: {} },
+            { id: 'parent', position: { x: 0, y: 0 }, data: {} },
             {
-              id: "child1",
+              id: 'child1',
               position: { x: 0, y: 0 },
               data: {},
-              parentId: "parent",
+              parentId: 'parent',
             },
             {
-              id: "child2",
+              id: 'child2',
               position: { x: 0, y: 0 },
               data: {},
-              parentId: "parent",
+              parentId: 'parent',
             },
           ] as Node[],
           edges: [],
         };
 
         const layoutedElkGraph: ElkNode = {
-          id: "root",
+          id: 'root',
           children: [
             {
-              id: "parent",
+              id: 'parent',
               x: 50,
               y: 100,
               width: 300,
               height: 200,
               children: [
-                { id: "child1", x: 10, y: 10, width: 100, height: 50 },
-                { id: "child2", x: 10, y: 70, width: 100, height: 50 },
+                { id: 'child1', x: 10, y: 10, width: 100, height: 50 },
+                { id: 'child2', x: 10, y: 70, width: 100, height: 50 },
               ],
             },
           ],
           edges: [],
         };
 
-        const result = matchReactFlowGraphWithElkLayoutedGraph(reactFlowGraph, layoutedElkGraph);
+        const result = matchReactFlowGraphWithElkLayoutedGraph(
+          reactFlowGraph,
+          layoutedElkGraph,
+        );
 
         // Parent node should be positioned
         expect(result.nodes[0].position).toEqual({ x: 50, y: 100 });
@@ -1011,39 +1143,39 @@ describe("autoLayout", () => {
         expect(result.nodes[2].height).toBe(50);
       });
 
-      it("handles deeply nested nodes", () => {
+      it('handles deeply nested nodes', () => {
         const reactFlowGraph: ReactFlowGraph = {
           nodes: [
-            { id: "level1", position: { x: 0, y: 0 }, data: {} },
+            { id: 'level1', position: { x: 0, y: 0 }, data: {} },
             {
-              id: "level2",
+              id: 'level2',
               position: { x: 0, y: 0 },
               data: {},
-              parentId: "level1",
+              parentId: 'level1',
             },
             {
-              id: "level3",
+              id: 'level3',
               position: { x: 0, y: 0 },
               data: {},
-              parentId: "level2",
+              parentId: 'level2',
             },
           ] as Node[],
           edges: [],
         };
 
         const layoutedElkGraph: ElkNode = {
-          id: "root",
+          id: 'root',
           children: [
             {
-              id: "level1",
+              id: 'level1',
               x: 0,
               y: 0,
               children: [
                 {
-                  id: "level2",
+                  id: 'level2',
                   x: 10,
                   y: 10,
-                  children: [{ id: "level3", x: 20, y: 20 }],
+                  children: [{ id: 'level3', x: 20, y: 20 }],
                 },
               ],
             },
@@ -1051,7 +1183,10 @@ describe("autoLayout", () => {
           edges: [],
         };
 
-        const result = matchReactFlowGraphWithElkLayoutedGraph(reactFlowGraph, layoutedElkGraph);
+        const result = matchReactFlowGraphWithElkLayoutedGraph(
+          reactFlowGraph,
+          layoutedElkGraph,
+        );
 
         expect(result.nodes[0].position).toEqual({ x: 0, y: 0 });
         expect(result.nodes[1].position).toEqual({ x: 10, y: 10 });
@@ -1059,39 +1194,49 @@ describe("autoLayout", () => {
       });
     });
 
-    describe("dimension handling with !== undefined", () => {
-      it("correctly handles width and height of 0", () => {
+    describe('dimension handling with !== undefined', () => {
+      it('correctly handles width and height of 0', () => {
         const reactFlowGraph: ReactFlowGraph = {
-          nodes: [{ id: "node1", position: { x: 0, y: 0 }, data: {} }] as Node[],
+          nodes: [
+            { id: 'node1', position: { x: 0, y: 0 }, data: {} },
+          ] as Node[],
           edges: [],
         };
 
         const layoutedElkGraph: ElkNode = {
-          id: "root",
-          children: [{ id: "node1", x: 50, y: 100, width: 0, height: 0 }],
+          id: 'root',
+          children: [{ id: 'node1', x: 50, y: 100, width: 0, height: 0 }],
           edges: [],
         };
 
-        const result = matchReactFlowGraphWithElkLayoutedGraph(reactFlowGraph, layoutedElkGraph);
+        const result = matchReactFlowGraphWithElkLayoutedGraph(
+          reactFlowGraph,
+          layoutedElkGraph,
+        );
 
         // Should include width and height even though they are 0
         expect(result.nodes[0].width).toBe(0);
         expect(result.nodes[0].height).toBe(0);
       });
 
-      it("does not add width/height when undefined", () => {
+      it('does not add width/height when undefined', () => {
         const reactFlowGraph: ReactFlowGraph = {
-          nodes: [{ id: "node1", position: { x: 0, y: 0 }, data: {} }] as Node[],
+          nodes: [
+            { id: 'node1', position: { x: 0, y: 0 }, data: {} },
+          ] as Node[],
           edges: [],
         };
 
         const layoutedElkGraph: ElkNode = {
-          id: "root",
-          children: [{ id: "node1", x: 50, y: 100 }],
+          id: 'root',
+          children: [{ id: 'node1', x: 50, y: 100 }],
           edges: [],
         };
 
-        const result = matchReactFlowGraphWithElkLayoutedGraph(reactFlowGraph, layoutedElkGraph);
+        const result = matchReactFlowGraphWithElkLayoutedGraph(
+          reactFlowGraph,
+          layoutedElkGraph,
+        );
 
         // Should not have width/height properties
         expect(result.nodes[0].width).toBeUndefined();
@@ -1099,8 +1244,8 @@ describe("autoLayout", () => {
       });
     });
 
-    describe("DEFAULT_NODE_SIZE", () => {
-      it("has correct default dimensions", () => {
+    describe('DEFAULT_NODE_SIZE', () => {
+      it('has correct default dimensions', () => {
         expect(DEFAULT_NODE_SIZE).toEqual({
           height: 65,
           width: 220,
@@ -1108,30 +1253,42 @@ describe("autoLayout", () => {
       });
     });
 
-    describe("ROOT_LAYOUT_OPTIONS", () => {
-      it("contains required ELK layout options", () => {
-        expect(ROOT_LAYOUT_OPTIONS["org.eclipse.elk.algorithm"]).toBe("org.eclipse.elk.layered");
-        expect(ROOT_LAYOUT_OPTIONS["org.eclipse.elk.direction"]).toBe("DOWN");
-        expect(ROOT_LAYOUT_OPTIONS["org.eclipse.elk.hierarchyHandling"]).toBe("INCLUDE_CHILDREN");
+    describe('ROOT_LAYOUT_OPTIONS', () => {
+      it('contains required ELK layout options', () => {
+        expect(ROOT_LAYOUT_OPTIONS['org.eclipse.elk.algorithm']).toBe(
+          'org.eclipse.elk.layered',
+        );
+        expect(ROOT_LAYOUT_OPTIONS['org.eclipse.elk.direction']).toBe('DOWN');
+        expect(ROOT_LAYOUT_OPTIONS['org.eclipse.elk.hierarchyHandling']).toBe(
+          'INCLUDE_CHILDREN',
+        );
       });
 
-      it("has proper spacing configuration", () => {
-        expect(ROOT_LAYOUT_OPTIONS["org.eclipse.elk.layered.spacing.edgeNode"]).toBe("24");
-        expect(ROOT_LAYOUT_OPTIONS["org.eclipse.elk.layered.spacing.componentComponent"]).toBe(
-          "70",
-        );
-        expect(ROOT_LAYOUT_OPTIONS["org.eclipse.elk.layered.spacing.nodeNodeBetweenLayers"]).toBe(
-          "80",
-        );
+      it('has proper spacing configuration', () => {
+        expect(
+          ROOT_LAYOUT_OPTIONS['org.eclipse.elk.layered.spacing.edgeNode'],
+        ).toBe('24');
+        expect(
+          ROOT_LAYOUT_OPTIONS[
+            'org.eclipse.elk.layered.spacing.componentComponent'
+          ],
+        ).toBe('70');
+        expect(
+          ROOT_LAYOUT_OPTIONS[
+            'org.eclipse.elk.layered.spacing.nodeNodeBetweenLayers'
+          ],
+        ).toBe('80');
       });
     });
 
-    describe("PARENT_LAYOUT_OPTIONS", () => {
-      it("extends ROOT_LAYOUT_OPTIONS with padding", () => {
-        expect(PARENT_LAYOUT_OPTIONS["org.eclipse.elk.padding"]).toBe(
-          "[top=60,left=20,bottom=20,right=20]",
+    describe('PARENT_LAYOUT_OPTIONS', () => {
+      it('extends ROOT_LAYOUT_OPTIONS with padding', () => {
+        expect(PARENT_LAYOUT_OPTIONS['org.eclipse.elk.padding']).toBe(
+          '[top=60,left=20,bottom=20,right=20]',
         );
-        expect(PARENT_LAYOUT_OPTIONS["org.eclipse.elk.algorithm"]).toBe("org.eclipse.elk.layered");
+        expect(PARENT_LAYOUT_OPTIONS['org.eclipse.elk.algorithm']).toBe(
+          'org.eclipse.elk.layered',
+        );
       });
     });
   });

--- a/packages/serverless-workflow-diagram-editor/tests/react-flow/diagram/autoLayout.integration.test.ts
+++ b/packages/serverless-workflow-diagram-editor/tests/react-flow/diagram/autoLayout.integration.test.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { ElkNode } from 'elkjs/lib/elk.bundled.js';
-import type { Node, Edge } from '@xyflow/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { ElkNode } from "elkjs/lib/elk.bundled.js";
+import type { Node, Edge } from "@xyflow/react";
 import {
   buildElkGraphFromReactFlowGraph,
   matchReactFlowGraphWithElkLayoutedGraph,
@@ -24,100 +24,98 @@ import {
   DEFAULT_NODE_SIZE,
   ROOT_LAYOUT_OPTIONS,
   PARENT_LAYOUT_OPTIONS,
-} from '../../../src/react-flow/diagram/autoLayout';
-import type { ReactFlowGraph } from '../../../src/react-flow/diagram/diagramBuilder';
-import * as core from '../../../src/core';
+} from "../../../src/react-flow/diagram/autoLayout";
+import type { ReactFlowGraph } from "../../../src/react-flow/diagram/diagramBuilder";
+import * as core from "../../../src/core";
 
 // Mock the processElkLayout function
-vi.mock('../../../src/core', () => ({
+vi.mock("../../../src/core", () => ({
   processElkLayout: vi.fn(),
 }));
 
-describe('autoLayout', () => {
-  describe('buildElkGraphFromReactFlowGraph', () => {
-    it('converts simple ReactFlow graph to ELK graph', () => {
+describe("autoLayout", () => {
+  describe("buildElkGraphFromReactFlowGraph", () => {
+    it("converts simple ReactFlow graph to ELK graph", () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
           {
-            id: 'node1',
+            id: "node1",
             position: { x: 0, y: 0 },
             data: {},
             measured: { width: 150, height: 50 },
           },
           {
-            id: 'node2',
+            id: "node2",
             position: { x: 0, y: 0 },
             data: {},
             measured: { width: 200, height: 60 },
           },
         ] as Node[],
-        edges: [
-          { id: 'edge1', source: 'node1', target: 'node2', data: {} },
-        ] as Edge[],
+        edges: [{ id: "edge1", source: "node1", target: "node2", data: {} }] as Edge[],
       };
 
       const elkGraph = buildElkGraphFromReactFlowGraph(reactFlowGraph);
 
-      expect(elkGraph.id).toBe('root');
+      expect(elkGraph.id).toBe("root");
       expect(elkGraph.layoutOptions).toEqual(ROOT_LAYOUT_OPTIONS);
       expect(elkGraph.children).toHaveLength(2);
       expect(elkGraph.children?.[0]).toEqual({
-        id: 'node1',
+        id: "node1",
         width: 150,
         height: 50,
         children: [],
       });
       expect(elkGraph.children?.[1]).toEqual({
-        id: 'node2',
+        id: "node2",
         width: 200,
         height: 60,
         children: [],
       });
       expect(elkGraph.edges).toHaveLength(1);
       expect(elkGraph.edges?.[0]).toEqual({
-        id: 'edge1',
-        sources: ['node1'],
-        targets: ['node2'],
+        id: "edge1",
+        sources: ["node1"],
+        targets: ["node2"],
       });
     });
 
-    it('uses default node size when measured dimensions are not available', () => {
+    it("uses default node size when measured dimensions are not available", () => {
       const reactFlowGraph: ReactFlowGraph = {
-        nodes: [{ id: 'node1', position: { x: 0, y: 0 }, data: {} }] as Node[],
+        nodes: [{ id: "node1", position: { x: 0, y: 0 }, data: {} }] as Node[],
         edges: [],
       };
 
       const elkGraph = buildElkGraphFromReactFlowGraph(reactFlowGraph);
 
       expect(elkGraph.children?.[0]).toEqual({
-        id: 'node1',
+        id: "node1",
         width: DEFAULT_NODE_SIZE.width,
         height: DEFAULT_NODE_SIZE.height,
         children: [],
       });
     });
 
-    it('handles nested nodes with parentId', () => {
+    it("handles nested nodes with parentId", () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
           {
-            id: 'parent',
+            id: "parent",
             position: { x: 0, y: 0 },
             data: {},
             measured: { width: 300, height: 200 },
           },
           {
-            id: 'child1',
+            id: "child1",
             position: { x: 10, y: 10 },
             data: {},
-            parentId: 'parent',
+            parentId: "parent",
             measured: { width: 100, height: 50 },
           },
           {
-            id: 'child2',
+            id: "child2",
             position: { x: 10, y: 70 },
             data: {},
-            parentId: 'parent',
+            parentId: "parent",
             measured: { width: 100, height: 50 },
           },
         ] as Node[],
@@ -127,13 +125,13 @@ describe('autoLayout', () => {
       const elkGraph = buildElkGraphFromReactFlowGraph(reactFlowGraph);
 
       expect(elkGraph.children).toHaveLength(1);
-      expect(elkGraph.children?.[0].id).toBe('parent');
+      expect(elkGraph.children?.[0].id).toBe("parent");
       expect(elkGraph.children?.[0].children).toHaveLength(2);
-      expect(elkGraph.children?.[0].children?.[0].id).toBe('child1');
-      expect(elkGraph.children?.[0].children?.[1].id).toBe('child2');
+      expect(elkGraph.children?.[0].children?.[0].id).toBe("child1");
+      expect(elkGraph.children?.[0].children?.[1].id).toBe("child2");
     });
 
-    it('handles empty graph', () => {
+    it("handles empty graph", () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [],
         edges: [],
@@ -141,20 +139,20 @@ describe('autoLayout', () => {
 
       const elkGraph = buildElkGraphFromReactFlowGraph(reactFlowGraph);
 
-      expect(elkGraph.id).toBe('root');
+      expect(elkGraph.id).toBe("root");
       expect(elkGraph.children).toHaveLength(0);
       expect(elkGraph.edges).toHaveLength(0);
     });
 
-    it('handles multiple edges between nodes', () => {
+    it("handles multiple edges between nodes", () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
-          { id: 'node1', position: { x: 0, y: 0 }, data: {} },
-          { id: 'node2', position: { x: 0, y: 0 }, data: {} },
+          { id: "node1", position: { x: 0, y: 0 }, data: {} },
+          { id: "node2", position: { x: 0, y: 0 }, data: {} },
         ] as Node[],
         edges: [
-          { id: 'edge1', source: 'node1', target: 'node2', data: {} },
-          { id: 'edge2', source: 'node2', target: 'node1', data: {} },
+          { id: "edge1", source: "node1", target: "node2", data: {} },
+          { id: "edge2", source: "node2", target: "node1", data: {} },
         ] as Edge[],
       };
 
@@ -162,25 +160,25 @@ describe('autoLayout', () => {
 
       expect(elkGraph.edges).toHaveLength(2);
       expect(elkGraph.edges?.[0]).toEqual({
-        id: 'edge1',
-        sources: ['node1'],
-        targets: ['node2'],
+        id: "edge1",
+        sources: ["node1"],
+        targets: ["node2"],
       });
       expect(elkGraph.edges?.[1]).toEqual({
-        id: 'edge2',
-        sources: ['node2'],
-        targets: ['node1'],
+        id: "edge2",
+        sources: ["node2"],
+        targets: ["node1"],
       });
     });
 
-    it('treat as a root-level if parentId is non-existent', () => {
+    it("treat as a root-level if parentId is non-existent", () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
           {
-            id: 'node1',
+            id: "node1",
             position: { x: 0, y: 0 },
             data: {},
-            parentId: 'nonexistent',
+            parentId: "nonexistent",
           },
         ] as Node[],
         edges: [],
@@ -189,23 +187,23 @@ describe('autoLayout', () => {
       const elkGraph = buildElkGraphFromReactFlowGraph(reactFlowGraph);
 
       expect(elkGraph.children).toHaveLength(1);
-      expect(elkGraph.children?.[0].id).toBe('node1');
+      expect(elkGraph.children?.[0].id).toBe("node1");
     });
 
-    it('applies PARENT_LAYOUT_OPTIONS to nodes with children', () => {
+    it("applies PARENT_LAYOUT_OPTIONS to nodes with children", () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
           {
-            id: 'parent',
+            id: "parent",
             position: { x: 0, y: 0 },
             data: {},
             measured: { width: 300, height: 200 },
           },
           {
-            id: 'child',
+            id: "child",
             position: { x: 10, y: 10 },
             data: {},
-            parentId: 'parent',
+            parentId: "parent",
             measured: { width: 100, height: 50 },
           },
         ] as Node[],
@@ -216,57 +214,41 @@ describe('autoLayout', () => {
 
       // Parent node should have layout options and no fixed dimensions
       expect(elkGraph.children?.[0].layoutOptions).toBeDefined();
-      expect(
-        elkGraph.children?.[0].layoutOptions?.['org.eclipse.elk.padding'],
-      ).toBe('[top=60,left=20,bottom=20,right=20]');
+      expect(elkGraph.children?.[0].layoutOptions?.["org.eclipse.elk.padding"]).toBe(
+        "[top=60,left=20,bottom=20,right=20]",
+      );
       expect(elkGraph.children?.[0].width).toBeUndefined();
       expect(elkGraph.children?.[0].height).toBeUndefined();
 
       // Child node should have fixed dimensions and no layout options
       expect(elkGraph.children?.[0].children?.[0].width).toBe(100);
       expect(elkGraph.children?.[0].children?.[0].height).toBe(50);
-      expect(
-        elkGraph.children?.[0].children?.[0].layoutOptions,
-      ).toBeUndefined();
+      expect(elkGraph.children?.[0].children?.[0].layoutOptions).toBeUndefined();
     });
 
-    it('places edges at correct hierarchy level - root level', () => {
+    it("places edges at correct hierarchy level - root level", () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
-          { id: 'node1', position: { x: 0, y: 0 }, data: {} },
-          { id: 'node2', position: { x: 0, y: 0 }, data: {} },
+          { id: "node1", position: { x: 0, y: 0 }, data: {} },
+          { id: "node2", position: { x: 0, y: 0 }, data: {} },
         ] as Node[],
-        edges: [
-          { id: 'edge1', source: 'node1', target: 'node2', data: {} },
-        ] as Edge[],
+        edges: [{ id: "edge1", source: "node1", target: "node2", data: {} }] as Edge[],
       };
 
       const elkGraph = buildElkGraphFromReactFlowGraph(reactFlowGraph);
 
       expect(elkGraph.edges).toHaveLength(1);
-      expect(elkGraph.edges?.[0].id).toBe('edge1');
+      expect(elkGraph.edges?.[0].id).toBe("edge1");
     });
 
-    it('places edges at correct hierarchy level - inside parent', () => {
+    it("places edges at correct hierarchy level - inside parent", () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
-          { id: 'parent', position: { x: 0, y: 0 }, data: {} },
-          {
-            id: 'child1',
-            position: { x: 0, y: 0 },
-            data: {},
-            parentId: 'parent',
-          },
-          {
-            id: 'child2',
-            position: { x: 0, y: 0 },
-            data: {},
-            parentId: 'parent',
-          },
+          { id: "parent", position: { x: 0, y: 0 }, data: {} },
+          { id: "child1", position: { x: 0, y: 0 }, data: {}, parentId: "parent" },
+          { id: "child2", position: { x: 0, y: 0 }, data: {}, parentId: "parent" },
         ] as Node[],
-        edges: [
-          { id: 'edge1', source: 'child1', target: 'child2', data: {} },
-        ] as Edge[],
+        edges: [{ id: "edge1", source: "child1", target: "child2", data: {} }] as Edge[],
       };
 
       const elkGraph = buildElkGraphFromReactFlowGraph(reactFlowGraph);
@@ -274,30 +256,18 @@ describe('autoLayout', () => {
       // Edge should be inside parent, not at root
       expect(elkGraph.edges).toHaveLength(0);
       expect(elkGraph.children?.[0].edges).toHaveLength(1);
-      expect(elkGraph.children?.[0].edges?.[0].id).toBe('edge1');
+      expect(elkGraph.children?.[0].edges?.[0].id).toBe("edge1");
     });
 
-    it('places edges at lowest common ancestor', () => {
+    it("places edges at lowest common ancestor", () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
-          { id: 'parent1', position: { x: 0, y: 0 }, data: {} },
-          {
-            id: 'child1',
-            position: { x: 0, y: 0 },
-            data: {},
-            parentId: 'parent1',
-          },
-          { id: 'parent2', position: { x: 0, y: 0 }, data: {} },
-          {
-            id: 'child2',
-            position: { x: 0, y: 0 },
-            data: {},
-            parentId: 'parent2',
-          },
+          { id: "parent1", position: { x: 0, y: 0 }, data: {} },
+          { id: "child1", position: { x: 0, y: 0 }, data: {}, parentId: "parent1" },
+          { id: "parent2", position: { x: 0, y: 0 }, data: {} },
+          { id: "child2", position: { x: 0, y: 0 }, data: {}, parentId: "parent2" },
         ] as Node[],
-        edges: [
-          { id: 'edge1', source: 'child1', target: 'child2', data: {} },
-        ] as Edge[],
+        edges: [{ id: "edge1", source: "child1", target: "child2", data: {} }] as Edge[],
       };
 
       const elkGraph = buildElkGraphFromReactFlowGraph(reactFlowGraph);
@@ -308,16 +278,11 @@ describe('autoLayout', () => {
       expect(elkGraph.children?.[1].edges).toBeUndefined();
     });
 
-    it('cleans up empty edges arrays', () => {
+    it("cleans up empty edges arrays", () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
-          { id: 'parent', position: { x: 0, y: 0 }, data: {} },
-          {
-            id: 'child',
-            position: { x: 0, y: 0 },
-            data: {},
-            parentId: 'parent',
-          },
+          { id: "parent", position: { x: 0, y: 0 }, data: {} },
+          { id: "child", position: { x: 0, y: 0 }, data: {}, parentId: "parent" },
         ] as Node[],
         edges: [],
       };
@@ -329,32 +294,15 @@ describe('autoLayout', () => {
       expect(elkGraph.children?.[0].children?.[0].edges).toBeUndefined();
     });
 
-    it('handles multi-level nesting with edges at different levels', () => {
+    it("handles multi-level nesting with edges at different levels", () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
-          { id: 'grandparent', position: { x: 0, y: 0 }, data: {} },
-          {
-            id: 'parent',
-            position: { x: 0, y: 0 },
-            data: {},
-            parentId: 'grandparent',
-          },
-          {
-            id: 'child1',
-            position: { x: 0, y: 0 },
-            data: {},
-            parentId: 'parent',
-          },
-          {
-            id: 'child2',
-            position: { x: 0, y: 0 },
-            data: {},
-            parentId: 'parent',
-          },
+          { id: "grandparent", position: { x: 0, y: 0 }, data: {} },
+          { id: "parent", position: { x: 0, y: 0 }, data: {}, parentId: "grandparent" },
+          { id: "child1", position: { x: 0, y: 0 }, data: {}, parentId: "parent" },
+          { id: "child2", position: { x: 0, y: 0 }, data: {}, parentId: "parent" },
         ] as Node[],
-        edges: [
-          { id: 'edge1', source: 'child1', target: 'child2', data: {} },
-        ] as Edge[],
+        edges: [{ id: "edge1", source: "child1", target: "child2", data: {} }] as Edge[],
       };
 
       const elkGraph = buildElkGraphFromReactFlowGraph(reactFlowGraph);
@@ -366,29 +314,26 @@ describe('autoLayout', () => {
     });
   });
 
-  describe('matchReactFlowGraphWithElkLayoutedGraph', () => {
-    it('updates node positions from ELK layout', () => {
+  describe("matchReactFlowGraphWithElkLayoutedGraph", () => {
+    it("updates node positions from ELK layout", () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
-          { id: 'node1', position: { x: 0, y: 0 }, data: {} },
-          { id: 'node2', position: { x: 0, y: 0 }, data: {} },
+          { id: "node1", position: { x: 0, y: 0 }, data: {} },
+          { id: "node2", position: { x: 0, y: 0 }, data: {} },
         ] as Node[],
         edges: [],
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: 'root',
+        id: "root",
         children: [
-          { id: 'node1', x: 50, y: 100, width: 200, height: 60 },
-          { id: 'node2', x: 50, y: 200, width: 200, height: 60 },
+          { id: "node1", x: 50, y: 100, width: 200, height: 60 },
+          { id: "node2", x: 50, y: 200, width: 200, height: 60 },
         ],
         edges: [],
       };
 
-      const result = matchReactFlowGraphWithElkLayoutedGraph(
-        reactFlowGraph,
-        layoutedElkGraph,
-      );
+      const result = matchReactFlowGraphWithElkLayoutedGraph(reactFlowGraph, layoutedElkGraph);
 
       expect(result.nodes[0].position).toEqual({ x: 50, y: 100 });
       expect(result.nodes[0].width).toBe(200);
@@ -396,54 +341,47 @@ describe('autoLayout', () => {
       expect(result.nodes[1].position).toEqual({ x: 50, y: 200 });
     });
 
-    it('preserves original node data when no ELK node found', () => {
+    it("preserves original node data when no ELK node found", () => {
       const reactFlowGraph: ReactFlowGraph = {
-        nodes: [
-          { id: 'node1', position: { x: 10, y: 20 }, data: { label: 'Test' } },
-        ] as Node[],
+        nodes: [{ id: "node1", position: { x: 10, y: 20 }, data: { label: "Test" } }] as Node[],
         edges: [],
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: 'root',
+        id: "root",
         children: [],
         edges: [],
       };
 
-      const result = matchReactFlowGraphWithElkLayoutedGraph(
-        reactFlowGraph,
-        layoutedElkGraph,
-      );
+      const result = matchReactFlowGraphWithElkLayoutedGraph(reactFlowGraph, layoutedElkGraph);
 
       expect(result.nodes[0].position).toEqual({ x: 10, y: 20 });
-      expect(result.nodes[0].data).toEqual({ label: 'Test' });
+      expect(result.nodes[0].data).toEqual({ label: "Test" });
     });
 
-    it('adds waypoints to edges from ELK bend points', () => {
+    it("adds waypoints to edges from ELK bend points", () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
-          { id: 'node1', position: { x: 0, y: 0 }, data: {} },
-          { id: 'node2', position: { x: 0, y: 0 }, data: {} },
+          { id: "node1", position: { x: 0, y: 0 }, data: {} },
+          { id: "node2", position: { x: 0, y: 0 }, data: {} },
         ] as Node[],
-        edges: [
-          { id: 'edge1', source: 'node1', target: 'node2', data: {} },
-        ] as Edge[],
+        edges: [{ id: "edge1", source: "node1", target: "node2", data: {} }] as Edge[],
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: 'root',
+        id: "root",
         children: [
-          { id: 'node1', x: 0, y: 0 },
-          { id: 'node2', x: 200, y: 100 },
+          { id: "node1", x: 0, y: 0 },
+          { id: "node2", x: 200, y: 100 },
         ],
         edges: [
           {
-            id: 'edge1',
-            sources: ['node1'],
-            targets: ['node2'],
+            id: "edge1",
+            sources: ["node1"],
+            targets: ["node2"],
             sections: [
               {
-                id: 'section1',
+                id: "section1",
                 startPoint: { x: 0, y: 0 },
                 endPoint: { x: 200, y: 100 },
                 bendPoints: [
@@ -456,10 +394,7 @@ describe('autoLayout', () => {
         ],
       };
 
-      const result = matchReactFlowGraphWithElkLayoutedGraph(
-        reactFlowGraph,
-        layoutedElkGraph,
-      );
+      const result = matchReactFlowGraphWithElkLayoutedGraph(reactFlowGraph, layoutedElkGraph);
 
       expect(result.edges[0].data?.wayPoints).toEqual([
         { x: 100, y: 0 },
@@ -467,31 +402,29 @@ describe('autoLayout', () => {
       ]);
     });
 
-    it('handles edges without bend points', () => {
+    it("handles edges without bend points", () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
-          { id: 'node1', position: { x: 0, y: 0 }, data: {} },
-          { id: 'node2', position: { x: 0, y: 0 }, data: {} },
+          { id: "node1", position: { x: 0, y: 0 }, data: {} },
+          { id: "node2", position: { x: 0, y: 0 }, data: {} },
         ] as Node[],
-        edges: [
-          { id: 'edge1', source: 'node1', target: 'node2', data: {} },
-        ] as Edge[],
+        edges: [{ id: "edge1", source: "node1", target: "node2", data: {} }] as Edge[],
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: 'root',
+        id: "root",
         children: [
-          { id: 'node1', x: 0, y: 0 },
-          { id: 'node2', x: 200, y: 0 },
+          { id: "node1", x: 0, y: 0 },
+          { id: "node2", x: 200, y: 0 },
         ],
         edges: [
           {
-            id: 'edge1',
-            sources: ['node1'],
-            targets: ['node2'],
+            id: "edge1",
+            sources: ["node1"],
+            targets: ["node2"],
             sections: [
               {
-                id: 'section1',
+                id: "section1",
                 startPoint: { x: 0, y: 0 },
                 endPoint: { x: 200, y: 0 },
               },
@@ -500,72 +433,66 @@ describe('autoLayout', () => {
         ],
       };
 
-      const result = matchReactFlowGraphWithElkLayoutedGraph(
-        reactFlowGraph,
-        layoutedElkGraph,
-      );
+      const result = matchReactFlowGraphWithElkLayoutedGraph(reactFlowGraph, layoutedElkGraph);
 
       expect(result.edges[0].data?.wayPoints).toBeUndefined();
     });
 
-    it('clears stale wayPoints when ELK edge has no sections', () => {
+    it("clears stale wayPoints when ELK edge has no sections", () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [],
         edges: [
           {
-            id: 'edge1',
-            source: 'node1',
-            target: 'node2',
-            data: { label: 'Test Edge', wayPoints: [{ x: 10, y: 20 }] },
+            id: "edge1",
+            source: "node1",
+            target: "node2",
+            data: { label: "Test Edge", wayPoints: [{ x: 10, y: 20 }] },
           },
         ] as Edge[],
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: 'root',
+        id: "root",
         children: [],
         edges: [
           {
-            id: 'edge1',
-            sources: ['node1'],
-            targets: ['node2'],
+            id: "edge1",
+            sources: ["node1"],
+            targets: ["node2"],
           },
         ],
       };
 
-      const result = matchReactFlowGraphWithElkLayoutedGraph(
-        reactFlowGraph,
-        layoutedElkGraph,
-      );
+      const result = matchReactFlowGraphWithElkLayoutedGraph(reactFlowGraph, layoutedElkGraph);
 
-      expect(result.edges[0].data).toEqual({ label: 'Test Edge' });
+      expect(result.edges[0].data).toEqual({ label: "Test Edge" });
       expect(result.edges[0].data?.wayPoints).toBeUndefined();
     });
 
-    it('clears stale wayPoints when ELK edge sections have no bend points', () => {
+    it("clears stale wayPoints when ELK edge sections have no bend points", () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [],
         edges: [
           {
-            id: 'edge1',
-            source: 'node1',
-            target: 'node2',
-            data: { label: 'Test Edge', wayPoints: [{ x: 10, y: 20 }] },
+            id: "edge1",
+            source: "node1",
+            target: "node2",
+            data: { label: "Test Edge", wayPoints: [{ x: 10, y: 20 }] },
           },
         ] as Edge[],
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: 'root',
+        id: "root",
         children: [],
         edges: [
           {
-            id: 'edge1',
-            sources: ['node1'],
-            targets: ['node2'],
+            id: "edge1",
+            sources: ["node1"],
+            targets: ["node2"],
             sections: [
               {
-                id: 'section1',
+                id: "section1",
                 startPoint: { x: 0, y: 0 },
                 endPoint: { x: 200, y: 0 },
               },
@@ -574,53 +501,47 @@ describe('autoLayout', () => {
         ],
       };
 
-      const result = matchReactFlowGraphWithElkLayoutedGraph(
-        reactFlowGraph,
-        layoutedElkGraph,
-      );
+      const result = matchReactFlowGraphWithElkLayoutedGraph(reactFlowGraph, layoutedElkGraph);
 
-      expect(result.edges[0].data).toEqual({ label: 'Test Edge' });
+      expect(result.edges[0].data).toEqual({ label: "Test Edge" });
       expect(result.edges[0].data?.wayPoints).toBeUndefined();
     });
 
-    it('preserves edge data when no ELK edge found', () => {
+    it("preserves edge data when no ELK edge found", () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [],
         edges: [
           {
-            id: 'edge1',
-            source: 'node1',
-            target: 'node2',
-            data: { label: 'Test Edge' },
+            id: "edge1",
+            source: "node1",
+            target: "node2",
+            data: { label: "Test Edge" },
           },
         ] as Edge[],
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: 'root',
+        id: "root",
         children: [],
         edges: [],
       };
 
-      const result = matchReactFlowGraphWithElkLayoutedGraph(
-        reactFlowGraph,
-        layoutedElkGraph,
-      );
+      const result = matchReactFlowGraphWithElkLayoutedGraph(reactFlowGraph, layoutedElkGraph);
 
-      expect(result.edges[0].data).toEqual({ label: 'Test Edge' });
+      expect(result.edges[0].data).toEqual({ label: "Test Edge" });
     });
 
-    it('does not mutate original graph', () => {
+    it("does not mutate original graph", () => {
       const reactFlowGraph: ReactFlowGraph = {
-        nodes: [{ id: 'node1', position: { x: 0, y: 0 }, data: {} }] as Node[],
+        nodes: [{ id: "node1", position: { x: 0, y: 0 }, data: {} }] as Node[],
         edges: [],
       };
 
       const originalPosition = { ...reactFlowGraph.nodes[0].position };
 
       const layoutedElkGraph: ElkNode = {
-        id: 'root',
-        children: [{ id: 'node1', x: 100, y: 200 }],
+        id: "root",
+        children: [{ id: "node1", x: 100, y: 200 }],
         edges: [],
       };
 
@@ -629,31 +550,29 @@ describe('autoLayout', () => {
       expect(reactFlowGraph.nodes[0].position).toEqual(originalPosition);
     });
 
-    it('handles multiple sections with bend points', () => {
+    it("handles multiple sections with bend points", () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [],
-        edges: [
-          { id: 'edge1', source: 'node1', target: 'node2', data: {} },
-        ] as Edge[],
+        edges: [{ id: "edge1", source: "node1", target: "node2", data: {} }] as Edge[],
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: 'root',
+        id: "root",
         children: [],
         edges: [
           {
-            id: 'edge1',
-            sources: ['node1'],
-            targets: ['node2'],
+            id: "edge1",
+            sources: ["node1"],
+            targets: ["node2"],
             sections: [
               {
-                id: 'section1',
+                id: "section1",
                 startPoint: { x: 0, y: 0 },
                 endPoint: { x: 100, y: 50 },
                 bendPoints: [{ x: 50, y: 0 }],
               },
               {
-                id: 'section2',
+                id: "section2",
                 startPoint: { x: 100, y: 50 },
                 endPoint: { x: 200, y: 100 },
                 bendPoints: [{ x: 150, y: 100 }],
@@ -663,10 +582,7 @@ describe('autoLayout', () => {
         ],
       };
 
-      const result = matchReactFlowGraphWithElkLayoutedGraph(
-        reactFlowGraph,
-        layoutedElkGraph,
-      );
+      const result = matchReactFlowGraphWithElkLayoutedGraph(reactFlowGraph, layoutedElkGraph);
 
       expect(result.edges[0].data?.wayPoints).toEqual([
         { x: 50, y: 0 },
@@ -674,47 +590,35 @@ describe('autoLayout', () => {
       ]);
     });
 
-    it('handles edges inside parent nodes - removes wayPoints', () => {
+    it("handles edges inside parent nodes - removes wayPoints", () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
-          { id: 'parent', position: { x: 0, y: 0 }, data: {} },
-          {
-            id: 'child1',
-            position: { x: 0, y: 0 },
-            data: {},
-            parentId: 'parent',
-          },
-          {
-            id: 'child2',
-            position: { x: 0, y: 0 },
-            data: {},
-            parentId: 'parent',
-          },
+          { id: "parent", position: { x: 0, y: 0 }, data: {} },
+          { id: "child1", position: { x: 0, y: 0 }, data: {}, parentId: "parent" },
+          { id: "child2", position: { x: 0, y: 0 }, data: {}, parentId: "parent" },
         ] as Node[],
-        edges: [
-          { id: 'edge1', source: 'child1', target: 'child2', data: {} },
-        ] as Edge[],
+        edges: [{ id: "edge1", source: "child1", target: "child2", data: {} }] as Edge[],
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: 'root',
+        id: "root",
         children: [
           {
-            id: 'parent',
+            id: "parent",
             x: 0,
             y: 0,
             children: [
-              { id: 'child1', x: 10, y: 10 },
-              { id: 'child2', x: 10, y: 70 },
+              { id: "child1", x: 10, y: 10 },
+              { id: "child2", x: 10, y: 70 },
             ],
             edges: [
               {
-                id: 'edge1',
-                sources: ['child1'],
-                targets: ['child2'],
+                id: "edge1",
+                sources: ["child1"],
+                targets: ["child2"],
                 sections: [
                   {
-                    id: 'section1',
+                    id: "section1",
                     startPoint: { x: 10, y: 10 },
                     endPoint: { x: 10, y: 70 },
                     bendPoints: [{ x: 10, y: 40 }],
@@ -727,62 +631,47 @@ describe('autoLayout', () => {
         edges: [],
       };
 
-      const result = matchReactFlowGraphWithElkLayoutedGraph(
-        reactFlowGraph,
-        layoutedElkGraph,
-      );
+      const result = matchReactFlowGraphWithElkLayoutedGraph(reactFlowGraph, layoutedElkGraph);
 
       // wayPoints should be undefined for edges inside parent nodes
       expect(result.edges[0].data?.wayPoints).toBeUndefined();
     });
 
-    it('preserves wayPoints for edges not inside parent nodes', () => {
+    it("preserves wayPoints for edges not inside parent nodes", () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
-          { id: 'parent1', position: { x: 0, y: 0 }, data: {} },
-          {
-            id: 'child1',
-            position: { x: 0, y: 0 },
-            data: {},
-            parentId: 'parent1',
-          },
-          { id: 'parent2', position: { x: 0, y: 0 }, data: {} },
-          {
-            id: 'child2',
-            position: { x: 0, y: 0 },
-            data: {},
-            parentId: 'parent2',
-          },
+          { id: "parent1", position: { x: 0, y: 0 }, data: {} },
+          { id: "child1", position: { x: 0, y: 0 }, data: {}, parentId: "parent1" },
+          { id: "parent2", position: { x: 0, y: 0 }, data: {} },
+          { id: "child2", position: { x: 0, y: 0 }, data: {}, parentId: "parent2" },
         ] as Node[],
-        edges: [
-          { id: 'edge1', source: 'child1', target: 'child2', data: {} },
-        ] as Edge[],
+        edges: [{ id: "edge1", source: "child1", target: "child2", data: {} }] as Edge[],
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: 'root',
+        id: "root",
         children: [
           {
-            id: 'parent1',
+            id: "parent1",
             x: 0,
             y: 0,
-            children: [{ id: 'child1', x: 10, y: 10 }],
+            children: [{ id: "child1", x: 10, y: 10 }],
           },
           {
-            id: 'parent2',
+            id: "parent2",
             x: 200,
             y: 0,
-            children: [{ id: 'child2', x: 10, y: 10 }],
+            children: [{ id: "child2", x: 10, y: 10 }],
           },
         ],
         edges: [
           {
-            id: 'edge1',
-            sources: ['child1'],
-            targets: ['child2'],
+            id: "edge1",
+            sources: ["child1"],
+            targets: ["child2"],
             sections: [
               {
-                id: 'section1',
+                id: "section1",
                 startPoint: { x: 10, y: 10 },
                 endPoint: { x: 210, y: 10 },
                 bendPoints: [{ x: 100, y: 10 }],
@@ -792,45 +681,42 @@ describe('autoLayout', () => {
         ],
       };
 
-      const result = matchReactFlowGraphWithElkLayoutedGraph(
-        reactFlowGraph,
-        layoutedElkGraph,
-      );
+      const result = matchReactFlowGraphWithElkLayoutedGraph(reactFlowGraph, layoutedElkGraph);
 
       // wayPoints should be preserved for edges crossing parent boundaries
       expect(result.edges[0].data?.wayPoints).toEqual([{ x: 100, y: 10 }]);
     });
 
-    it('preserves other edge data when updating wayPoints', () => {
+    it("preserves other edge data when updating wayPoints", () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
-          { id: 'node1', position: { x: 0, y: 0 }, data: {} },
-          { id: 'node2', position: { x: 0, y: 0 }, data: {} },
+          { id: "node1", position: { x: 0, y: 0 }, data: {} },
+          { id: "node2", position: { x: 0, y: 0 }, data: {} },
         ] as Node[],
         edges: [
           {
-            id: 'edge1',
-            source: 'node1',
-            target: 'node2',
-            data: { label: 'Test', color: 'blue', customProp: 123 },
+            id: "edge1",
+            source: "node1",
+            target: "node2",
+            data: { label: "Test", color: "blue", customProp: 123 },
           },
         ] as Edge[],
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: 'root',
+        id: "root",
         children: [
-          { id: 'node1', x: 0, y: 0 },
-          { id: 'node2', x: 200, y: 100 },
+          { id: "node1", x: 0, y: 0 },
+          { id: "node2", x: 200, y: 100 },
         ],
         edges: [
           {
-            id: 'edge1',
-            sources: ['node1'],
-            targets: ['node2'],
+            id: "edge1",
+            sources: ["node1"],
+            targets: ["node2"],
             sections: [
               {
-                id: 'section1',
+                id: "section1",
                 startPoint: { x: 0, y: 0 },
                 endPoint: { x: 200, y: 100 },
                 bendPoints: [{ x: 100, y: 50 }],
@@ -840,21 +726,18 @@ describe('autoLayout', () => {
         ],
       };
 
-      const result = matchReactFlowGraphWithElkLayoutedGraph(
-        reactFlowGraph,
-        layoutedElkGraph,
-      );
+      const result = matchReactFlowGraphWithElkLayoutedGraph(reactFlowGraph, layoutedElkGraph);
 
       expect(result.edges[0].data).toEqual({
-        label: 'Test',
-        color: 'blue',
+        label: "Test",
+        color: "blue",
         customProp: 123,
         wayPoints: [{ x: 100, y: 50 }],
       });
     });
   });
 
-  describe('applyAutoLayout', () => {
+  describe("applyAutoLayout", () => {
     beforeEach(() => {
       vi.clearAllMocks();
     });
@@ -863,38 +746,36 @@ describe('autoLayout', () => {
       vi.restoreAllMocks();
     });
 
-    it('applies auto layout successfully', async () => {
+    it("applies auto layout successfully", async () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
           {
-            id: 'node1',
+            id: "node1",
             position: { x: 0, y: 0 },
             data: {},
             measured: { width: 200, height: 60 },
           },
           {
-            id: 'node2',
+            id: "node2",
             position: { x: 0, y: 0 },
             data: {},
             measured: { width: 200, height: 60 },
           },
         ] as Node[],
-        edges: [
-          { id: 'edge1', source: 'node1', target: 'node2', data: {} },
-        ] as Edge[],
+        edges: [{ id: "edge1", source: "node1", target: "node2", data: {} }] as Edge[],
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: 'root',
+        id: "root",
         children: [
-          { id: 'node1', x: 50, y: 100, width: 200, height: 60 },
-          { id: 'node2', x: 50, y: 200, width: 200, height: 60 },
+          { id: "node1", x: 50, y: 100, width: 200, height: 60 },
+          { id: "node2", x: 50, y: 200, width: 200, height: 60 },
         ],
         edges: [
           {
-            id: 'edge1',
-            sources: ['node1'],
-            targets: ['node2'],
+            id: "edge1",
+            sources: ["node1"],
+            targets: ["node2"],
           },
         ],
       };
@@ -908,11 +789,9 @@ describe('autoLayout', () => {
       expect(result.nodes[1].position).toEqual({ x: 50, y: 200 });
     });
 
-    it('returns original graph when ELK layout fails', async () => {
+    it("returns original graph when ELK layout fails", async () => {
       const reactFlowGraph: ReactFlowGraph = {
-        nodes: [
-          { id: 'node1', position: { x: 10, y: 20 }, data: {} },
-        ] as Node[],
+        nodes: [{ id: "node1", position: { x: 10, y: 20 }, data: {} }] as Node[],
         edges: [],
       };
 
@@ -924,14 +803,14 @@ describe('autoLayout', () => {
       expect(result.nodes[0].position).toEqual({ x: 10, y: 20 });
     });
 
-    it('handles empty graph', async () => {
+    it("handles empty graph", async () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [],
         edges: [],
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: 'root',
+        id: "root",
         children: [],
         edges: [],
       };
@@ -944,11 +823,11 @@ describe('autoLayout', () => {
       expect(result.edges).toHaveLength(0);
     });
 
-    it('passes correct ELK graph structure to processElkLayout', async () => {
+    it("passes correct ELK graph structure to processElkLayout", async () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
           {
-            id: 'node1',
+            id: "node1",
             position: { x: 0, y: 0 },
             data: {},
             measured: { width: 150, height: 50 },
@@ -958,8 +837,8 @@ describe('autoLayout', () => {
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: 'root',
-        children: [{ id: 'node1', x: 0, y: 0 }],
+        id: "root",
+        children: [{ id: "node1", x: 0, y: 0 }],
         edges: [],
       };
 
@@ -969,11 +848,11 @@ describe('autoLayout', () => {
 
       expect(core.processElkLayout).toHaveBeenCalledWith(
         {
-          id: 'root',
+          id: "root",
           layoutOptions: ROOT_LAYOUT_OPTIONS,
           children: [
             {
-              id: 'node1',
+              id: "node1",
               width: 150,
               height: 50,
               children: [],
@@ -985,52 +864,50 @@ describe('autoLayout', () => {
       );
     });
 
-    it('handles complex graph with nested nodes and edges', async () => {
+    it("handles complex graph with nested nodes and edges", async () => {
       const reactFlowGraph: ReactFlowGraph = {
         nodes: [
           {
-            id: 'parent',
+            id: "parent",
             position: { x: 0, y: 0 },
             data: {},
             measured: { width: 300, height: 200 },
           },
           {
-            id: 'child1',
+            id: "child1",
             position: { x: 10, y: 10 },
             data: {},
-            parentId: 'parent',
+            parentId: "parent",
             measured: { width: 100, height: 50 },
           },
           {
-            id: 'node2',
+            id: "node2",
             position: { x: 0, y: 0 },
             data: {},
             measured: { width: 200, height: 60 },
           },
         ] as Node[],
-        edges: [
-          { id: 'edge1', source: 'parent', target: 'node2', data: {} },
-        ] as Edge[],
+        edges: [{ id: "edge1", source: "parent", target: "node2", data: {} }] as Edge[],
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: 'root',
+        id: "root",
         children: [
           {
-            id: 'parent',
+            id: "parent",
             x: 0,
             y: 0,
             width: 300,
             height: 200,
-            children: [{ id: 'child1', x: 10, y: 10, width: 100, height: 50 }],
+            children: [{ id: "child1", x: 10, y: 10, width: 100, height: 50 }],
           },
-          { id: 'node2', x: 350, y: 50, width: 200, height: 60 },
+          { id: "node2", x: 350, y: 50, width: 200, height: 60 },
         ],
         edges: [
           {
-            id: 'edge1',
-            sources: ['parent'],
-            targets: ['node2'],
+            id: "edge1",
+            sources: ["parent"],
+            targets: ["node2"],
           },
         ],
       };
@@ -1044,15 +921,15 @@ describe('autoLayout', () => {
       expect(result.nodes[2].position).toEqual({ x: 350, y: 50 });
     });
 
-    it('passes abort signal to processElkLayout', async () => {
+    it("passes abort signal to processElkLayout", async () => {
       const reactFlowGraph: ReactFlowGraph = {
-        nodes: [{ id: 'node1', position: { x: 0, y: 0 }, data: {} }] as Node[],
+        nodes: [{ id: "node1", position: { x: 0, y: 0 }, data: {} }] as Node[],
         edges: [],
       };
 
       const layoutedElkGraph: ElkNode = {
-        id: 'root',
-        children: [{ id: 'node1', x: 50, y: 100 }],
+        id: "root",
+        children: [{ id: "node1", x: 50, y: 100 }],
         edges: [],
       };
 
@@ -1067,66 +944,57 @@ describe('autoLayout', () => {
       );
     });
 
-    it('handles processElkLayout rejection gracefully', async () => {
+    it("handles processElkLayout rejection gracefully", async () => {
       const reactFlowGraph: ReactFlowGraph = {
-        nodes: [
-          { id: 'node1', position: { x: 10, y: 20 }, data: {} },
-        ] as Node[],
+        nodes: [{ id: "node1", position: { x: 10, y: 20 }, data: {} }] as Node[],
         edges: [],
       };
 
-      vi.mocked(core.processElkLayout).mockRejectedValue(
-        new Error('Layout failed'),
-      );
+      vi.mocked(core.processElkLayout).mockRejectedValue(new Error("Layout failed"));
 
-      await expect(applyAutoLayout(reactFlowGraph)).rejects.toThrow(
-        'Layout failed',
-      );
+      await expect(applyAutoLayout(reactFlowGraph)).rejects.toThrow("Layout failed");
     });
 
-    describe('buildElkNodeMap helper', () => {
-      it('handles nested nodes correctly in matchReactFlowGraphWithElkLayoutedGraph', () => {
+    describe("buildElkNodeMap helper", () => {
+      it("handles nested nodes correctly in matchReactFlowGraphWithElkLayoutedGraph", () => {
         const reactFlowGraph: ReactFlowGraph = {
           nodes: [
-            { id: 'parent', position: { x: 0, y: 0 }, data: {} },
+            { id: "parent", position: { x: 0, y: 0 }, data: {} },
             {
-              id: 'child1',
+              id: "child1",
               position: { x: 0, y: 0 },
               data: {},
-              parentId: 'parent',
+              parentId: "parent",
             },
             {
-              id: 'child2',
+              id: "child2",
               position: { x: 0, y: 0 },
               data: {},
-              parentId: 'parent',
+              parentId: "parent",
             },
           ] as Node[],
           edges: [],
         };
 
         const layoutedElkGraph: ElkNode = {
-          id: 'root',
+          id: "root",
           children: [
             {
-              id: 'parent',
+              id: "parent",
               x: 50,
               y: 100,
               width: 300,
               height: 200,
               children: [
-                { id: 'child1', x: 10, y: 10, width: 100, height: 50 },
-                { id: 'child2', x: 10, y: 70, width: 100, height: 50 },
+                { id: "child1", x: 10, y: 10, width: 100, height: 50 },
+                { id: "child2", x: 10, y: 70, width: 100, height: 50 },
               ],
             },
           ],
           edges: [],
         };
 
-        const result = matchReactFlowGraphWithElkLayoutedGraph(
-          reactFlowGraph,
-          layoutedElkGraph,
-        );
+        const result = matchReactFlowGraphWithElkLayoutedGraph(reactFlowGraph, layoutedElkGraph);
 
         // Parent node should be positioned
         expect(result.nodes[0].position).toEqual({ x: 50, y: 100 });
@@ -1143,39 +1011,39 @@ describe('autoLayout', () => {
         expect(result.nodes[2].height).toBe(50);
       });
 
-      it('handles deeply nested nodes', () => {
+      it("handles deeply nested nodes", () => {
         const reactFlowGraph: ReactFlowGraph = {
           nodes: [
-            { id: 'level1', position: { x: 0, y: 0 }, data: {} },
+            { id: "level1", position: { x: 0, y: 0 }, data: {} },
             {
-              id: 'level2',
+              id: "level2",
               position: { x: 0, y: 0 },
               data: {},
-              parentId: 'level1',
+              parentId: "level1",
             },
             {
-              id: 'level3',
+              id: "level3",
               position: { x: 0, y: 0 },
               data: {},
-              parentId: 'level2',
+              parentId: "level2",
             },
           ] as Node[],
           edges: [],
         };
 
         const layoutedElkGraph: ElkNode = {
-          id: 'root',
+          id: "root",
           children: [
             {
-              id: 'level1',
+              id: "level1",
               x: 0,
               y: 0,
               children: [
                 {
-                  id: 'level2',
+                  id: "level2",
                   x: 10,
                   y: 10,
-                  children: [{ id: 'level3', x: 20, y: 20 }],
+                  children: [{ id: "level3", x: 20, y: 20 }],
                 },
               ],
             },
@@ -1183,10 +1051,7 @@ describe('autoLayout', () => {
           edges: [],
         };
 
-        const result = matchReactFlowGraphWithElkLayoutedGraph(
-          reactFlowGraph,
-          layoutedElkGraph,
-        );
+        const result = matchReactFlowGraphWithElkLayoutedGraph(reactFlowGraph, layoutedElkGraph);
 
         expect(result.nodes[0].position).toEqual({ x: 0, y: 0 });
         expect(result.nodes[1].position).toEqual({ x: 10, y: 10 });
@@ -1194,49 +1059,39 @@ describe('autoLayout', () => {
       });
     });
 
-    describe('dimension handling with !== undefined', () => {
-      it('correctly handles width and height of 0', () => {
+    describe("dimension handling with !== undefined", () => {
+      it("correctly handles width and height of 0", () => {
         const reactFlowGraph: ReactFlowGraph = {
-          nodes: [
-            { id: 'node1', position: { x: 0, y: 0 }, data: {} },
-          ] as Node[],
+          nodes: [{ id: "node1", position: { x: 0, y: 0 }, data: {} }] as Node[],
           edges: [],
         };
 
         const layoutedElkGraph: ElkNode = {
-          id: 'root',
-          children: [{ id: 'node1', x: 50, y: 100, width: 0, height: 0 }],
+          id: "root",
+          children: [{ id: "node1", x: 50, y: 100, width: 0, height: 0 }],
           edges: [],
         };
 
-        const result = matchReactFlowGraphWithElkLayoutedGraph(
-          reactFlowGraph,
-          layoutedElkGraph,
-        );
+        const result = matchReactFlowGraphWithElkLayoutedGraph(reactFlowGraph, layoutedElkGraph);
 
         // Should include width and height even though they are 0
         expect(result.nodes[0].width).toBe(0);
         expect(result.nodes[0].height).toBe(0);
       });
 
-      it('does not add width/height when undefined', () => {
+      it("does not add width/height when undefined", () => {
         const reactFlowGraph: ReactFlowGraph = {
-          nodes: [
-            { id: 'node1', position: { x: 0, y: 0 }, data: {} },
-          ] as Node[],
+          nodes: [{ id: "node1", position: { x: 0, y: 0 }, data: {} }] as Node[],
           edges: [],
         };
 
         const layoutedElkGraph: ElkNode = {
-          id: 'root',
-          children: [{ id: 'node1', x: 50, y: 100 }],
+          id: "root",
+          children: [{ id: "node1", x: 50, y: 100 }],
           edges: [],
         };
 
-        const result = matchReactFlowGraphWithElkLayoutedGraph(
-          reactFlowGraph,
-          layoutedElkGraph,
-        );
+        const result = matchReactFlowGraphWithElkLayoutedGraph(reactFlowGraph, layoutedElkGraph);
 
         // Should not have width/height properties
         expect(result.nodes[0].width).toBeUndefined();
@@ -1244,8 +1099,8 @@ describe('autoLayout', () => {
       });
     });
 
-    describe('DEFAULT_NODE_SIZE', () => {
-      it('has correct default dimensions', () => {
+    describe("DEFAULT_NODE_SIZE", () => {
+      it("has correct default dimensions", () => {
         expect(DEFAULT_NODE_SIZE).toEqual({
           height: 65,
           width: 220,
@@ -1253,42 +1108,30 @@ describe('autoLayout', () => {
       });
     });
 
-    describe('ROOT_LAYOUT_OPTIONS', () => {
-      it('contains required ELK layout options', () => {
-        expect(ROOT_LAYOUT_OPTIONS['org.eclipse.elk.algorithm']).toBe(
-          'org.eclipse.elk.layered',
-        );
-        expect(ROOT_LAYOUT_OPTIONS['org.eclipse.elk.direction']).toBe('DOWN');
-        expect(ROOT_LAYOUT_OPTIONS['org.eclipse.elk.hierarchyHandling']).toBe(
-          'INCLUDE_CHILDREN',
-        );
+    describe("ROOT_LAYOUT_OPTIONS", () => {
+      it("contains required ELK layout options", () => {
+        expect(ROOT_LAYOUT_OPTIONS["org.eclipse.elk.algorithm"]).toBe("org.eclipse.elk.layered");
+        expect(ROOT_LAYOUT_OPTIONS["org.eclipse.elk.direction"]).toBe("DOWN");
+        expect(ROOT_LAYOUT_OPTIONS["org.eclipse.elk.hierarchyHandling"]).toBe("INCLUDE_CHILDREN");
       });
 
-      it('has proper spacing configuration', () => {
-        expect(
-          ROOT_LAYOUT_OPTIONS['org.eclipse.elk.layered.spacing.edgeNode'],
-        ).toBe('24');
-        expect(
-          ROOT_LAYOUT_OPTIONS[
-            'org.eclipse.elk.layered.spacing.componentComponent'
-          ],
-        ).toBe('70');
-        expect(
-          ROOT_LAYOUT_OPTIONS[
-            'org.eclipse.elk.layered.spacing.nodeNodeBetweenLayers'
-          ],
-        ).toBe('80');
+      it("has proper spacing configuration", () => {
+        expect(ROOT_LAYOUT_OPTIONS["org.eclipse.elk.layered.spacing.edgeNode"]).toBe("24");
+        expect(ROOT_LAYOUT_OPTIONS["org.eclipse.elk.layered.spacing.componentComponent"]).toBe(
+          "70",
+        );
+        expect(ROOT_LAYOUT_OPTIONS["org.eclipse.elk.layered.spacing.nodeNodeBetweenLayers"]).toBe(
+          "50",
+        );
       });
     });
 
-    describe('PARENT_LAYOUT_OPTIONS', () => {
-      it('extends ROOT_LAYOUT_OPTIONS with padding', () => {
-        expect(PARENT_LAYOUT_OPTIONS['org.eclipse.elk.padding']).toBe(
-          '[top=60,left=20,bottom=20,right=20]',
+    describe("PARENT_LAYOUT_OPTIONS", () => {
+      it("extends ROOT_LAYOUT_OPTIONS with padding", () => {
+        expect(PARENT_LAYOUT_OPTIONS["org.eclipse.elk.padding"]).toBe(
+          "[top=60,left=20,bottom=20,right=20]",
         );
-        expect(PARENT_LAYOUT_OPTIONS['org.eclipse.elk.algorithm']).toBe(
-          'org.eclipse.elk.layered',
-        );
+        expect(PARENT_LAYOUT_OPTIONS["org.eclipse.elk.algorithm"]).toBe("org.eclipse.elk.layered");
       });
     });
   });

--- a/packages/serverless-workflow-diagram-editor/tests/react-flow/diagram/diagramBuilder.test.ts
+++ b/packages/serverless-workflow-diagram-editor/tests/react-flow/diagram/diagramBuilder.test.ts
@@ -24,6 +24,11 @@ import {
   getCatchContainerNodeIds,
 } from "../../../src/react-flow/diagram/diagramBuilder";
 import { EdgeTypes } from "../../../src/react-flow/edges/Edges";
+import {
+  DEFAULT_NODE_SIZE,
+  TERMINAL_NODE_SIZE,
+  getNodeSize,
+} from "../../../src/react-flow/diagram/autoLayout";
 import { parseWorkflow } from "../../../src/core";
 import {
   BASIC_VALID_WORKFLOW_JSON,
@@ -637,6 +642,66 @@ describe("diagramBuilder", () => {
             expect(nodesWithOutgoingEdges.has(node.id)).toBe(true);
           }
         });
+      });
+    });
+  });
+
+  describe("node sizing", () => {
+    const workflowWithContainers = JSON.stringify({
+      document: {
+        dsl: "1.0.3",
+        name: "workflow-with-containers",
+        version: "1.0.0",
+        namespace: "default",
+      },
+      do: [
+        {
+          tryBlock: {
+            try: [{ step1: { set: { variable: "task" } } }],
+            catch: {
+              errors: { with: { type: "https://example.com/errors/test" } },
+              do: [{ recover: { set: { variable: "recovery" } } }],
+            },
+          },
+        },
+      ],
+    });
+
+    it.each([GraphNodeType.Entry, GraphNodeType.Exit])(
+      "getNodeSize returns the terminal node size for %s",
+      (type) => {
+        expect(getNodeSize(type)).toEqual(TERMINAL_NODE_SIZE);
+      },
+    );
+
+    it.each([
+      GraphNodeType.Call,
+      GraphNodeType.Do,
+      GraphNodeType.Start,
+      GraphNodeType.End,
+      undefined,
+    ])("getNodeSize returns the default size for %s", (type) => {
+      expect(getNodeSize(type)).toEqual(DEFAULT_NODE_SIZE);
+    });
+
+    it("assigns the terminal size to entry/exit nodes and the default size to others", () => {
+      const diagram = buildDiagramFromWorkflow(workflowWithContainers);
+
+      const terminals = diagram.nodes.filter(
+        (node) => node.type === GraphNodeType.Entry || node.type === GraphNodeType.Exit,
+      );
+      expect(terminals.length).toBeGreaterThan(0);
+      terminals.forEach((node) => {
+        expect(node.width).toBe(TERMINAL_NODE_SIZE.width);
+        expect(node.height).toBe(TERMINAL_NODE_SIZE.height);
+      });
+
+      const nonTerminals = diagram.nodes.filter(
+        (node) => node.type !== GraphNodeType.Entry && node.type !== GraphNodeType.Exit,
+      );
+      nonTerminals.forEach((node) => {
+        expect(node.width).toBe(DEFAULT_NODE_SIZE.width);
+        expect(node.height).toBe(DEFAULT_NODE_SIZE.height);
       });
     });
   });

--- a/packages/serverless-workflow-diagram-editor/tests/react-flow/nodes/Nodes.test.tsx
+++ b/packages/serverless-workflow-diagram-editor/tests/react-flow/nodes/Nodes.test.tsx
@@ -22,10 +22,14 @@ import { ReactFlowNodeTypes } from "../../../src/react-flow/nodes/Nodes";
 import {
   containerNodeConfigMap,
   leafNodeConfigMap,
+  terminalNodeConfigMap,
   type ContainerNodeType,
   type LeafNodeType,
+  type TerminalNodeType,
 } from "../../../src/react-flow/nodes/taskNodeConfig";
 import { DEFAULT_NODE_SIZE } from "../../../src/react-flow/diagram/autoLayout";
+import { en } from "../../../src/i18n/locales/en";
+import { renderWithProviders } from "../../test-utils/render-helpers";
 
 function testNode(
   id: string,
@@ -169,6 +173,43 @@ describe("React Flow custom node types", () => {
       );
       expect(node.style.getPropertyValue("--task-node-color")).toBe(config.color);
     });
+  });
+
+  describe("should render terminal nodes with TerminalNodeContent", () => {
+    const terminalNodes: {
+      id: string;
+      type: TerminalNodeType;
+      testId: string;
+      handleType: "source" | "target";
+    }[] = [
+      { id: "entry1", type: GraphNodeType.Entry, testId: "entry", handleType: "source" },
+      { id: "exit1", type: GraphNodeType.Exit, testId: "exit", handleType: "target" },
+    ];
+
+    it.each(terminalNodes)(
+      "renders $testId node as a neutral pill",
+      ({ id, type, testId, handleType }) => {
+        const nodes = [testNode(id, type, 0, "raw-label-should-not-show")];
+        renderWithProviders(
+          <div>
+            <RF.ReactFlow nodeTypes={ReactFlowNodeTypes} nodes={nodes} edges={[]} />
+          </div>,
+        );
+
+        const node = screen.getByTestId(`${testId}-node-${id}`);
+        const label = en[terminalNodeConfigMap[type].labelKey];
+
+        expect(node).toHaveClass("dec-terminal-node");
+        // shows the translated label, not the node's raw data.label
+        expect(node).toHaveTextContent(label);
+        expect(node).not.toHaveTextContent("raw-label-should-not-show");
+
+        // renders single handle source or target
+        const handles = node.querySelectorAll(".react-flow__handle");
+        expect(handles).toHaveLength(1);
+        expect(handles[0]).toHaveClass(handleType);
+      },
+    );
   });
 
   describe("badge rendering", () => {

--- a/packages/serverless-workflow-diagram-editor/tests/react-flow/nodes/taskNodeConfig.test.ts
+++ b/packages/serverless-workflow-diagram-editor/tests/react-flow/nodes/taskNodeConfig.test.ts
@@ -20,10 +20,13 @@ import {
   CATCH_CONTAINER_NODE_TYPE,
   type ContainerNodeType,
   type LeafNodeType,
+  type TerminalNodeType,
   containerNodeConfigMap,
   getNodeVisualConfig,
   leafNodeConfigMap,
+  terminalNodeConfigMap,
 } from "../../../src/react-flow/nodes/taskNodeConfig";
+import { en } from "../../../src/i18n/locales/en";
 
 const leafNodeTypes: LeafNodeType[] = [
   GraphNodeType.Call,
@@ -45,6 +48,8 @@ const containerNodeTypes: ContainerNodeType[] = [
   GraphNodeType.TryCatch,
   CATCH_CONTAINER_NODE_TYPE,
 ];
+
+const terminalNodeTypes: TerminalNodeType[] = [GraphNodeType.Entry, GraphNodeType.Exit];
 
 describe("taskNodeConfig", () => {
   it("should have config for all leaf nodes", () => {
@@ -78,6 +83,22 @@ describe("taskNodeConfig", () => {
     },
   );
 
+  it("should have config for terminal nodes", () => {
+    for (const terminal of terminalNodeTypes) {
+      expect(terminalNodeConfigMap[terminal]).toBeDefined();
+    }
+  });
+
+  it.each(terminalNodeTypes)(
+    "should have icon and a valid labelKey for terminal %s",
+    (terminal) => {
+      const config = terminalNodeConfigMap[terminal];
+
+      expect(config.icon).toBeDefined();
+      expect(en[config.labelKey]).toBeDefined();
+    },
+  );
+
   describe("getNodeVisualConfig", () => {
     it("resolves a leaf node type", () => {
       expect(getNodeVisualConfig(GraphNodeType.Call)).toBe(leafNodeConfigMap[GraphNodeType.Call]);
@@ -96,6 +117,13 @@ describe("taskNodeConfig", () => {
     it("returns undefined for an unknown type", () => {
       expect(getNodeVisualConfig("not-a-node-type")).toBeUndefined();
     });
+
+    it.each(terminalNodeTypes)(
+      "returns undefined for terminal node type %s",
+      (terminal) => {
+        expect(getNodeVisualConfig(terminal)).toBeUndefined();
+      },
+    );
 
     it("returns undefined when type is undefined", () => {
       expect(getNodeVisualConfig(undefined)).toBeUndefined();


### PR DESCRIPTION
Closes: https://github.com/serverlessworkflow/editor/issues/140

### Summary 
Replace placeholder nodes for entry exit container nodes

### Changes

  - Add new `TerminalNodeContent` component
  - Add terminal node config
  - Add getNodeSize() for autoLayout
  - Reduce spacing between nodes