### PR TITLE
fix: Waypoint Edge label positioning

### DIFF
--- a/packages/serverless-workflow-diagram-editor/src/react-flow/edges/Edges.tsx
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/edges/Edges.tsx
@@ -15,7 +15,7 @@
  */
 
 import * as RF from "@xyflow/react";
-import type { WayPoints } from "../diagram/autoLayout";
+import type { Point, WayPoints } from "../diagram/autoLayout";
 
 export enum EdgeTypes {
   Default = "default",
@@ -39,6 +39,8 @@ export type EdgeLabelProps = {
   sourceY: number;
   targetX: number;
   targetY: number;
+  sourcePosition?: RF.Position;
+  targetPosition?: RF.Position;
   type?: EdgeTypes;
   data?: BaseEdgeData | undefined;
 };
@@ -64,14 +66,72 @@ export function createPathFromWayPoints(
   return path;
 }
 
-export function EdgeLabel({ sourceX, sourceY, targetX, targetY, type, data }: EdgeLabelProps) {
+/**
+ * Picks the middle bend point of a waypoint path.
+ * With an even number of bends, averages the two central ones.
+ */
+export function getWayPointsMidpoint(wayPoints: WayPoints): Point | undefined {
+  if (wayPoints.length === 0) {
+    return undefined;
+  }
+  const middle = wayPoints.length / 2;
+
+  if (wayPoints.length % 2 === 1) {
+    return wayPoints[Math.floor(middle)];
+  }
+
+  const before = wayPoints[middle - 1];
+  const after = wayPoints[middle];
+
+  if (!before || !after) {
+    return undefined;
+  }
+  return { x: (before.x + after.x) / 2, y: (before.y + after.y) / 2 };
+}
+
+/**
+ * Resolves where the label sits:
+ * - waypoint edges uses getWayPointsMidpoint
+ * - smooth-step edges reuse React Flow's default
+ */
+function getEdgeLabelPosition({
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition = RF.Position.Bottom,
+  targetPosition = RF.Position.Top,
+  data,
+}: EdgeLabelProps): Point {
+  if (data?.wayPoints && data.wayPoints.length > 0) {
+    const midpoint = getWayPointsMidpoint(data.wayPoints);
+    if (midpoint) {
+      return midpoint;
+    }
+  }
+
+  const [, labelX, labelY] = RF.getSmoothStepPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  });
+  return { x: labelX, y: labelY };
+}
+
+export function EdgeLabel(props: EdgeLabelProps) {
+  const { type, data } = props;
+  const { x, y } = getEdgeLabelPosition(props);
+
   return (
     <>
       {data?.label && (
         <RF.EdgeLabelRenderer>
           <div
             style={{
-              transform: `translate(-50%, -50%) translate(${(sourceX + targetX) / 2}px,${(sourceY + targetY) / 2}px)`,
+              transform: `translate(-50%, -50%) translate(${x}px,${y}px)`,
             }}
             className={type ? `edge-label ${type}` : "edge-label"}
           >

--- a/packages/serverless-workflow-diagram-editor/tests/react-flow/edges/Edges.test.tsx
+++ b/packages/serverless-workflow-diagram-editor/tests/react-flow/edges/Edges.test.tsx
@@ -25,6 +25,7 @@ import {
   ReactFlowEdgeTypes,
   ErrorEdge,
   createPathFromWayPoints,
+  getWayPointsMidpoint,
 } from "../../../src/react-flow/edges/Edges";
 import * as RF from "@xyflow/react";
 
@@ -288,5 +289,93 @@ describe("EdgeLabel component", () => {
       const path = container.querySelector(selector);
       expect(path).toBeTruthy();
     });
+  });
+});
+
+describe("getWayPointsMidpoint helper function", () => {
+  it.each([
+    {
+      description: "single bend point returns that point",
+      wayPoints: [{ x: 50, y: 0 }],
+      expected: { x: 50, y: 0 },
+    },
+    {
+      description: "odd count returns the central bend point",
+      wayPoints: [
+        { x: 25, y: 0 },
+        { x: 50, y: 50 },
+        { x: 75, y: 0 },
+      ],
+      expected: { x: 50, y: 50 },
+    },
+    {
+      description: "even count averages the two central bend points",
+      wayPoints: [
+        { x: 100, y: 0 },
+        { x: 100, y: 100 },
+      ],
+      expected: { x: 100, y: 50 },
+    },
+    {
+      description: "even count of four averages the two central bend points",
+      wayPoints: [
+        { x: 0, y: 0 },
+        { x: 40, y: 20 },
+        { x: 60, y: 40 },
+        { x: 100, y: 100 },
+      ],
+      expected: { x: 50, y: 30 },
+    },
+    {
+      description: "negative coordinates",
+      wayPoints: [{ x: -25, y: -75 }],
+      expected: { x: -25, y: -75 },
+    },
+  ])("$description", ({ wayPoints, expected }) => {
+    const result = getWayPointsMidpoint(wayPoints);
+    expect(result?.x).toBeCloseTo(expected.x);
+    expect(result?.y).toBeCloseTo(expected.y);
+  });
+
+  it("returns undefined for an empty path", () => {
+    expect(getWayPointsMidpoint([])).toBeUndefined();
+  });
+});
+
+describe("EdgeLabel positioning", () => {
+  it("positions a waypoint edge label on the middle bend point of the custom path", () => {
+    const wayPoints = [{ x: 100, y: 0 }];
+    const mid = getWayPointsMidpoint(wayPoints);
+
+    const result = EdgeLabel({
+      sourceX: 0,
+      sourceY: 0,
+      targetX: 100,
+      targetY: 100,
+      data: { label: "Test", wayPoints },
+    });
+
+    expect(JSON.stringify(result)).toContain(`translate(${mid?.x}px,${mid?.y}px)`);
+  });
+
+  it("positions a smooth-step edge label using React Flow's default behaviour", () => {
+    const [, labelX, labelY] = RF.getSmoothStepPath({
+      sourceX: 0,
+      sourceY: 0,
+      sourcePosition: RF.Position.Bottom,
+      targetX: 100,
+      targetY: 40,
+      targetPosition: RF.Position.Top,
+    });
+
+    const result = EdgeLabel({
+      sourceX: 0,
+      sourceY: 0,
+      targetX: 100,
+      targetY: 40,
+      data: { label: "Test" },
+    });
+
+    expect(JSON.stringify(result)).toContain(`translate(${labelX}px,${labelY}px)`);
   });
 });


### PR DESCRIPTION
Closes: https://github.com/serverlessworkflow/editor/issues/171

### Summary
Fix edge labels floating off their line 

### Changes

- Calculate label positions on waypoint edges at the middle bend point of the path
- Position labels on smooth step edges using React Flow's `labelX/labelY`