### PR TITLE
chore: bump sdk package

### DIFF
--- a/.changeset/bump-sdk-package.md
+++ b/.changeset/bump-sdk-package.md
@@ -1,0 +1,5 @@
+---
+"@serverlessworkflow/diagram-editor": minor
+---
+
+Bump sdk typescript package

--- a/packages/serverless-workflow-diagram-editor/tests/core/__snapshots__/workflowSdk.integration.test.ts.snap
+++ b/packages/serverless-workflow-diagram-editor/tests/core/__snapshots__/workflowSdk.integration.test.ts.snap
@@ -691,7 +691,7 @@ exports[`parseWorkflow > returns model and errors for invalid but parseable 'JSO
   "errors": [
     {
       "errorType": "'Workflow' is invalid",
-      "message": "The DSL version of the workflow 'undefined' doesn't match the supported version of the SDK '1.0.3'.",
+      "message": "The DSL version of the workflow 'undefined' does not satisfy the DSL version range supported by this SDK '>=1.0.0 <=1.0.3'.",
     },
   ],
   "model": Workflow {
@@ -713,7 +713,7 @@ exports[`parseWorkflow > returns model and errors for invalid but parseable 'YAM
   "errors": [
     {
       "errorType": "'Workflow' is invalid",
-      "message": "The DSL version of the workflow 'undefined' doesn't match the supported version of the SDK '1.0.3'.",
+      "message": "The DSL version of the workflow 'undefined' does not satisfy the DSL version range supported by this SDK '>=1.0.0 <=1.0.3'.",
     },
   ],
   "model": Workflow {
@@ -734,7 +734,7 @@ exports[`validateWorkflow > returns parsed validation errors for an invalid work
 [
   {
     "errorType": "'Workflow' is invalid",
-    "message": "The DSL version of the workflow 'undefined' doesn't match the supported version of the SDK '1.0.3'.",
+    "message": "The DSL version of the workflow 'undefined' does not satisfy the DSL version range supported by this SDK '>=1.0.0 <=1.0.3'.",
   },
 ]
 `;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ catalogs:
       specifier: ^1.61.0
       version: 1.61.0
     '@serverlessworkflow/sdk':
-      specifier: ^1.0.3-alpha1
-      version: 1.0.3-alpha1
+      specifier: ^1.0.3-alpha3
+      version: 1.0.3-alpha3
     '@storybook/addon-a11y':
       specifier: ^10.4.6
       version: 10.4.6
@@ -93,6 +93,9 @@ catalogs:
     jsdom:
       specifier: ^29.1.0
       version: 29.1.1
+    lint-staged:
+      specifier: ^17.0.8
+      version: 17.0.8
     lucide-react:
       specifier: ^1.21.0
       version: 1.21.0
@@ -153,7 +156,7 @@ importers:
         specifier: 'catalog:'
         version: 9.1.7
       lint-staged:
-        specifier: 17.0.8
+        specifier: 'catalog:'
         version: 17.0.8
       oxfmt:
         specifier: 'catalog:'
@@ -208,7 +211,7 @@ importers:
         version: link:../i18n
       '@serverlessworkflow/sdk':
         specifier: 'catalog:'
-        version: 1.0.3-alpha1
+        version: 1.0.3-alpha3
       '@xyflow/react':
         specifier: 'catalog:'
         version: 12.11.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -2079,8 +2082,8 @@ packages:
       rollup:
         optional: true
 
-  '@serverlessworkflow/sdk@1.0.3-alpha1':
-    resolution: {integrity: sha512-I0h+AMnWC/monzHYC6x7Cy3RzHHCSsOfDQkZQXyXu7vc2jYIs95Mk0XUJdCr+FDyamdErp72w0N9Oj58ybYthA==}
+  '@serverlessworkflow/sdk@1.0.3-alpha3':
+    resolution: {integrity: sha512-rAI7bbEVc/OgA9X9Y0xZ/rdQhGwf+V9+BT/H/zqjVJfPqiMNduD28+RO90fTx0I56BII/nSlaKsgrnyJYH5/bA==}
     engines: {node: '>=22.0.0', npm: '>=10.0.0'}
 
   '@standard-schema/spec@1.1.0':
@@ -3520,6 +3523,11 @@ packages:
 
   semver@7.8.0:
     resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -5573,11 +5581,12 @@ snapshots:
       estree-walker: 2.0.2
       picomatch: 4.0.4
 
-  '@serverlessworkflow/sdk@1.0.3-alpha1':
+  '@serverlessworkflow/sdk@1.0.3-alpha3':
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       js-yaml: 4.2.0
+      semver: 7.8.5
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -7077,6 +7086,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.8.0: {}
+
+  semver@7.8.5: {}
 
   shebang-command@2.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,7 @@ catalog:
   "@changesets/cli": ^2.31.0
   "@chromatic-com/storybook": ^5.2.0
   "@playwright/test": ^1.61.0
-  "@serverlessworkflow/sdk": ^1.0.3-alpha1
+  "@serverlessworkflow/sdk": ^1.0.3-alpha3
   "@storybook/addon-a11y": ^10.4.6
   "@storybook/addon-docs": ^10.4.6
   "@storybook/addon-vitest": ^10.4.6


### PR DESCRIPTION
Closes: https://github.com/serverlessworkflow/editor/issues/204

### Summary

A bug in the TypeScript SDK (https://github.com/serverlessworkflow/sdk-typescript/issues/266) caused valid 1.0.x workflows to fail validation. Update sdk package to pull in fix

**Before fix:**
Error for valid `1.0.0` workflow
<img width="944" height="692" alt="Screenshot 2026-06-26 at 09 34 12" src="https://github.com/user-attachments/assets/7289fb98-7528-4312-89ad-03870c6e92b4" />

**After fix:**
No error in valid dsl version
<img width="1025" height="577" alt="Screenshot 2026-06-26 at 09 36 21" src="https://github.com/user-attachments/assets/81edfff0-5f31-40c9-afa4-3a2fc0e045dd" />

See errors for invalid dsl version 
<img width="1062" height="623" alt="Screenshot 2026-06-26 at 10 15 56" src="https://github.com/user-attachments/assets/2b761228-839f-449d-8505-f4ab8d831e2b" />



### Changes
- Bump sdk package to `1.0.3-alpha3`
- Update snapshot tests