### PR TITLE
feat: Styling tweaks

### DIFF
--- a/.changeset/style-minimap.md
+++ b/.changeset/style-minimap.md
@@ -1,0 +1,5 @@
+---
+"@serverlessworkflow/diagram-editor": patch
+---
+
+Small styling tweaks to minimap and buttons

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.css
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.css
@@ -68,23 +68,23 @@
 
   /* minimap */
   .dec-root .react-flow__minimap{
-  --xy-minimap-background-color: var(--dec-minimap-bg);
-  --xy-minimap-mask-background-color: var(--dec-minimap-mask);
-  --xy-minimap-mask-stroke-color: var(--dec-minimap-viewport);
-  --xy-minimap-node-background-color: var(--dec-minimap-node);
-  --xy-minimap-node-stroke-color: var(--dec-minimap-node-stroke);
-  --xy-minimap-node-stroke-width: 2;
-  
-  border: 1px solid var(--dec-minimap-border);
-  border-radius:8px;
-  box-shadow: 0 4px 12px var(--dec-minimap-shadow);
-  overflow: hidden;
+    --xy-minimap-background-color: var(--dec-minimap-bg);
+    --xy-minimap-mask-background-color: var(--dec-minimap-mask);
+    --xy-minimap-mask-stroke-color: var(--dec-minimap-viewport);
+    --xy-minimap-node-background-color: var(--dec-minimap-node);
+    --xy-minimap-node-stroke-color: var(--dec-minimap-node-stroke);
+    --xy-minimap-node-stroke-width: 2;
+    
+    border: 1px solid var(--dec-minimap-border);
+    border-radius:8px;
+    box-shadow: 0 4px 12px var(--dec-minimap-shadow);
+    overflow: hidden;
 }
 
   .dec-root .react-flow__minimap-node {
-  fill: var(--dec-minimap-node);
-  stroke: var(--dec-minimap-node-stroke);
-  stroke-width: 2;
+    fill: var(--dec-minimap-node);
+    stroke: var(--dec-minimap-node-stroke);
+    stroke-width: 2;
 }
 }
 

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.css
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.css
@@ -65,6 +65,27 @@
     min-width: 0 !important;
     min-height: 0 !important;
   }
+
+  /* minimap */
+  .dec-root .react-flow__minimap{
+  --xy-minimap-background-color: var(--dec-minimap-bg);
+  --xy-minimap-mask-background-color: var(--dec-minimap-mask);
+  --xy-minimap-mask-stroke-color: var(--dec-minimap-viewport);
+  --xy-minimap-node-background-color: var(--dec-minimap-node);
+  --xy-minimap-node-stroke-color: var(--dec-minimap-node-stroke);
+  --xy-minimap-node-stroke-width: 2;
+  
+  border: 1px solid var(--dec-minimap-border);
+  border-radius:8px;
+  box-shadow: 0 4px 12px var(--dec-minimap-shadow);
+  overflow: hidden;
+}
+
+  .dec-root .react-flow__minimap-node {
+  fill: var(--dec-minimap-node);
+  stroke: var(--dec-minimap-node-stroke);
+  stroke-width: 2;
+}
 }
 
 /* custom nodes */

--- a/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.tsx
+++ b/packages/serverless-workflow-diagram-editor/src/react-flow/diagram/Diagram.tsx
@@ -176,7 +176,9 @@ export const Diagram = ({ divRef, ref, colorMode = "light" }: DiagramProps) => {
         nodesDraggable={!isReadOnly}
         nodesConnectable={!isReadOnly}
       >
-        {minimapVisible && <RF.MiniMap pannable zoomable position={"top-right"} />}
+        {minimapVisible && (
+          <RF.MiniMap pannable zoomable position={"bottom-left"} maskStrokeWidth={2} />
+        )}
 
         <RF.Panel position="top-right">
           <SidePanelTrigger />

--- a/packages/serverless-workflow-diagram-editor/src/side-panel/MermaidActions.tsx
+++ b/packages/serverless-workflow-diagram-editor/src/side-panel/MermaidActions.tsx
@@ -74,11 +74,21 @@ export function MermaidActions({ model }: { model: Specification.Workflow }): Re
 
   return (
     <>
-      <Button onClick={handleCopyMermaid} variant="outline" size="sm">
+      <Button
+        onClick={handleCopyMermaid}
+        variant="outline"
+        size="sm"
+        className="dec:cursor-pointer"
+      >
         {isCopied ? <ClipboardCheck /> : <ClipboardPen />}
         {isCopied ? t("sidebar.exportMermaid.copied") : t("sidebar.exportMermaid.copy")}
       </Button>
-      <Button onClick={handleDownloadMermaid} variant="outline" size="sm">
+      <Button
+        onClick={handleDownloadMermaid}
+        variant="outline"
+        size="sm"
+        className="dec:cursor-pointer"
+      >
         <Download />
         {t("sidebar.exportMermaid.download")}
       </Button>

--- a/packages/serverless-workflow-diagram-editor/src/styles.css
+++ b/packages/serverless-workflow-diagram-editor/src/styles.css
@@ -58,10 +58,9 @@
     --dec-minimap-node-stroke: #64748b;
     --dec-minimap-border: #cbd5e1;
     --dec-minimap-shadow: rgba(15, 23, 42, 0.12);
-
   }
 
-  .dec-root.dark{
+  .dec-root.dark {
     --dec-error-accent: #f87171;
     --dec-error-glow: rgba(248, 113, 113, 0.4);
     --dec-edge-selected: #aea6a6;

--- a/packages/serverless-workflow-diagram-editor/src/styles.css
+++ b/packages/serverless-workflow-diagram-editor/src/styles.css
@@ -49,13 +49,32 @@
     --dec-error-glow: rgba(239, 68, 68, 0.35);
     --dec-edge-selected: #aea6a6;
     --dec-edge-selected-condition: rgb(59 130 246);
+
+    /* minimap */
+    --dec-minimap-bg: #f8fafc;
+    --dec-minimap-mask: rgba(100, 116, 139, 0.25);
+    --dec-minimap-viewport: rgb(59 130 246);
+    --dec-minimap-node: #94a3b8;
+    --dec-minimap-node-stroke: #64748b;
+    --dec-minimap-border: #cbd5e1;
+    --dec-minimap-shadow: rgba(15, 23, 42, 0.12);
+
   }
 
   .dec-root.dark{
-        --dec-error-accent: #f87171;
+    --dec-error-accent: #f87171;
     --dec-error-glow: rgba(248, 113, 113, 0.4);
     --dec-edge-selected: #aea6a6;
     --dec-edge-selected-condition: rgb(59 130 246);
+  
+    /* minimap */
+    --dec-minimap-bg: #1a202c;
+    --dec-minimap-mask: rgba(2, 6, 23, 0.5);
+    --dec-minimap-viewport: rgb(96 165 250);
+    --dec-minimap-node: #94a3b8;
+    --dec-minimap-node-stroke: #cbd5e1;
+    --dec-minimap-border: #2d3748;
+    --dec-minimap-shadow: rgba(0, 0, 0, 0.5);
   }
 
   .dec-root .dec-diagram-content {


### PR DESCRIPTION
Contributes to: https://github.com/serverlessworkflow/editor/issues/143

### Summary
Small improvements to styling

### Changes
- Move and style minimap to be more user friendly
- Add cursor to sidepanel buttons


<img width="597" height="231" alt="Screenshot 2026-06-26 at 14 21 52" src="https://github.com/user-attachments/assets/feb8b410-dcd3-4bbf-af30-f0764d353466" />
<img width="559" height="222" alt="Screenshot 2026-06-26 at 14 22 06" src="https://github.com/user-attachments/assets/5ab24917-435e-4fea-b1b3-2def8b3c36fc" />
