### PR TITLE
fix: validation errors after sdk node id changes

### DIFF
--- a/.changeset/task-reference-validation.md
+++ b/.changeset/task-reference-validation.md
@@ -1,0 +1,5 @@
+---
+"@openworkflowspec/diagram-editor": minor
+---
+
+Use new sdk task reference for validation errors

--- a/packages/open-workflow-diagram-editor/src/core/graph.ts
+++ b/packages/open-workflow-diagram-editor/src/core/graph.ts
@@ -20,6 +20,18 @@ export function getNodesByType(graph: FlatGraph, type: GraphNodeType): FlatGraph
   return graph.nodes.filter((node) => node.type === type);
 }
 
+/* The indexed JSON pointers of every task-backed node, where validation error paths live in.
+ */
+export function getTaskReferences(graph: FlatGraph): Set<string> {
+  const taskReferences = new Set<string>();
+  for (const node of graph.nodes) {
+    if (node.taskReference !== undefined) {
+      taskReferences.add(node.taskReference);
+    }
+  }
+  return taskReferences;
+}
+
 // Helper function to check if target is outside source's parent hierarchy
 export function isTargetOutsideSourceParent(
   sourceNode: FlatGraphNode,

--- a/packages/open-workflow-diagram-editor/src/core/validationErrors.ts
+++ b/packages/open-workflow-diagram-editor/src/core/validationErrors.ts
@@ -75,10 +75,7 @@ function isNodeError(error: SdkError): error is NodeError {
 }
 
 /* Find the task owning this error path. Both sides are JSON pointers, so the longest matching taskReference is found by dropping trailing segments until one is known. */
-export function findOwningTaskReference(
-  path: string,
-  taskReferences: Set<string>,
-): string | undefined {
+function findOwningTaskReference(path: string, taskReferences: Set<string>): string | undefined {
   let candidate = path;
 
   while (candidate.length > 0) {

--- a/packages/open-workflow-diagram-editor/src/core/validationErrors.ts
+++ b/packages/open-workflow-diagram-editor/src/core/validationErrors.ts
@@ -74,32 +74,44 @@ function isNodeError(error: SdkError): error is NodeError {
   return isValidationError(error) && error.path !== undefined && !isNoiseError(error);
 }
 
-/* Match the longest id prefix to find owning node */
-function findOwningNode(path: string, nodeIds: Set<string>): string | undefined {
-  let owner: string | undefined;
-  for (const id of nodeIds) {
-    if (path === id || path.startsWith(`${id}/`)) {
-      if (owner === undefined || id.length > owner.length) {
-        owner = id;
-      }
+/* Find the task owning this error path. Both sides are JSON pointers, so the longest matching taskReference is found by dropping trailing segments until one is known. */
+export function findOwningTaskReference(
+  path: string,
+  taskReferences: Set<string>,
+): string | undefined {
+  let candidate = path;
+
+  while (candidate.length > 0) {
+    if (taskReferences.has(candidate)) {
+      return candidate;
     }
+    const cut = candidate.lastIndexOf("/");
+    if (cut <= 0) {
+      break;
+    }
+    candidate = candidate.slice(0, cut);
   }
-  return owner;
+  return undefined;
 }
 
-/* returns errors for a particular node and removes noise */
+/* returns errors for a particular task and removes noise */
 export function getNodeErrors(
   errors: SdkError[],
-  nodeId: string,
-  nodeIds: Set<string>,
+  taskReference: string,
+  taskReferences: Set<string>,
 ): ValidationError[] {
   return errors.filter((error): error is NodeError => {
-    return isNodeError(error) && findOwningNode(error.path, nodeIds) === nodeId;
+    return (
+      isNodeError(error) && findOwningTaskReference(error.path, taskReferences) === taskReference
+    );
   });
 }
 
-export function getNodeErrorField(error: ValidationError, nodeId: string): string | undefined {
-  const prefix = `${nodeId}/`;
+export function getNodeErrorField(
+  error: ValidationError,
+  taskReference: string,
+): string | undefined {
+  const prefix = `${taskReference}/`;
   if (error.path === undefined || !error.path.startsWith(prefix)) {
     return undefined;
   }
@@ -107,27 +119,30 @@ export function getNodeErrorField(error: ValidationError, nodeId: string): strin
   return error.path.slice(prefix.length).split("/").join(".");
 }
 
-/* To quickly lookup nodeIds that should display badge and outline */
-export function getErrorNodeIds(errors: SdkError[], nodeIds: Set<string>): Set<string> {
-  const ids = new Set<string>();
+/* To quickly lookup the tasks that should display badge and outline */
+export function getErrorTaskReferences(
+  errors: SdkError[],
+  taskReferences: Set<string>,
+): Set<string> {
+  const owners = new Set<string>();
   for (const error of errors) {
     if (!isNodeError(error)) {
       continue;
     }
-    const owner = findOwningNode(error.path, nodeIds);
+    const owner = findOwningTaskReference(error.path, taskReferences);
     if (owner !== undefined) {
-      ids.add(owner);
+      owners.add(owner);
     }
   }
-  return ids;
+  return owners;
 }
 
 /* Errors not associated with node (workflow-level errors) */
-export function getGeneralErrors(errors: SdkError[], nodeIds: Set<string>): SdkError[] {
+export function getGeneralErrors(errors: SdkError[], taskReferences: Set<string>): SdkError[] {
   return errors.filter((error) => {
     if (!isValidationError(error) || error.path === undefined) {
       return true;
     }
-    return findOwningNode(error.path, nodeIds) === undefined;
+    return findOwningTaskReference(error.path, taskReferences) === undefined;
   });
 }

--- a/packages/open-workflow-diagram-editor/src/react-flow/diagram/diagramBuilder.ts
+++ b/packages/open-workflow-diagram-editor/src/react-flow/diagram/diagramBuilder.ts
@@ -15,7 +15,12 @@
  */
 
 import * as RF from "@xyflow/react";
-import { buildFlatGraph, getErrorNodeIds, type SdkError } from "../../core";
+import {
+  buildFlatGraph,
+  getErrorTaskReferences,
+  getTaskReferences,
+  type SdkError,
+} from "../../core";
 import { BaseNodeData, ReactFlowNodeTypes } from "../nodes/Nodes";
 import { BaseEdgeData, EdgeTypes } from "../edges/Edges";
 import * as sdk from "@openworkflowspec/sdk";
@@ -76,7 +81,7 @@ function resolveNodeType(graphNode: sdk.FlatGraphNode, catchContainerIds: Set<st
 function buildReactFlowNode(
   graphNode: sdk.FlatGraphNode,
   catchContainerIds: Set<string>,
-  erroringNodeIds: Set<string>,
+  erroringTaskReferences: Set<string>,
 ): RF.Node<BaseNodeData> {
   const type = resolveNodeType(graphNode, catchContainerIds);
   // There is no corresponding react flow component implemented
@@ -93,7 +98,10 @@ function buildReactFlowNode(
     data: {
       label: graphNode.label ?? "",
       ...(graphNode.task !== undefined && { task: structuredClone(graphNode.task) }),
-      ...(erroringNodeIds.has(graphNode.id) && { hasError: true }),
+      ...(graphNode.taskReference !== undefined && {
+        taskReference: graphNode.taskReference,
+        ...(erroringTaskReferences.has(graphNode.taskReference) && { hasError: true }),
+      }),
     },
     height: size.height,
     width: size.width,
@@ -134,11 +142,10 @@ export function buildDiagramElements(
   if (model) {
     const graph = buildFlatGraph(model);
     const catchContainerIds = getCatchContainerNodeIds(graph);
-    const nodeIds = new Set(graph.nodes.map((graphNode) => graphNode.id));
-    const nodeIdsWithErrors = getErrorNodeIds(errors, nodeIds);
+    const erroringTaskReferences = getErrorTaskReferences(errors, getTaskReferences(graph));
 
     graph.nodes.forEach((graphNode) =>
-      nodes.push(buildReactFlowNode(graphNode, catchContainerIds, nodeIdsWithErrors)),
+      nodes.push(buildReactFlowNode(graphNode, catchContainerIds, erroringTaskReferences)),
     );
 
     // Precompute node ID set for O(1) membership checks

--- a/packages/open-workflow-diagram-editor/src/react-flow/nodes/Nodes.tsx
+++ b/packages/open-workflow-diagram-editor/src/react-flow/nodes/Nodes.tsx
@@ -74,6 +74,7 @@ const KNOWN_BADGES = new Set([
 export type BaseNodeData<T = Specification.Task | void> = {
   label: string;
   task?: T;
+  taskReference?: string;
   hasError?: boolean;
 };
 

--- a/packages/open-workflow-diagram-editor/src/side-panel/NodeDetailsView.tsx
+++ b/packages/open-workflow-diagram-editor/src/side-panel/NodeDetailsView.tsx
@@ -51,12 +51,14 @@ function FieldRow({ label, field }: { label: string; field: DetailField }) {
 
 export function NodeDetailsView({ node }: NodeDetailsViewProps) {
   const { t } = useI18n();
-  const { errors, nodeIds, isReadOnly } = useDiagramEditorContext();
+  const { errors, taskReferences, isReadOnly } = useDiagramEditorContext();
   const task = node.data.task;
+  const taskReference = node.data.taskReference;
 
-  const nodeErrors = getNodeErrors(errors, node.id, nodeIds);
+  /* Layout-only nodes (entry/exit/start/end) have no taskReference, so no error can be owned by them */
+  const nodeErrors = taskReference ? getNodeErrors(errors, taskReference, taskReferences) : [];
   const errorItems = nodeErrors.map((error) => {
-    const field = getNodeErrorField(error, node.id);
+    const field = taskReference ? getNodeErrorField(error, taskReference) : undefined;
     return field !== undefined ? { message: error.message, field } : { message: error.message };
   });
   const fields = task ? getTaskDetails(task) : [];

--- a/packages/open-workflow-diagram-editor/src/side-panel/SidePanelTrigger.tsx
+++ b/packages/open-workflow-diagram-editor/src/side-panel/SidePanelTrigger.tsx
@@ -19,10 +19,10 @@ import { SidebarTrigger, useSidebar } from "@/components/ui/sidebar";
 import { getGeneralErrors } from "@/core";
 
 export function SidePanelTrigger() {
-  const { errors, nodeIds, setSelectedNodeId } = useDiagramEditorContext();
+  const { errors, taskReferences, setSelectedNodeId } = useDiagramEditorContext();
   const { setOpen } = useSidebar();
 
-  const count = getGeneralErrors(errors, nodeIds).length;
+  const count = getGeneralErrors(errors, taskReferences).length;
 
   const showWorkflowErrors = () => {
     setSelectedNodeId(null);

--- a/packages/open-workflow-diagram-editor/src/side-panel/WorkflowInfoView.tsx
+++ b/packages/open-workflow-diagram-editor/src/side-panel/WorkflowInfoView.tsx
@@ -27,9 +27,9 @@ type WorkflowInfoViewProps = {
 
 export function WorkflowInfoView({ document }: WorkflowInfoViewProps) {
   const { t } = useI18n();
-  const { errors, nodeIds } = useDiagramEditorContext();
+  const { errors, taskReferences } = useDiagramEditorContext();
 
-  const generalErrors = getGeneralErrors(errors, nodeIds).map((error) => ({
+  const generalErrors = getGeneralErrors(errors, taskReferences).map((error) => ({
     message: error.message,
   }));
 

--- a/packages/open-workflow-diagram-editor/src/store/DiagramEditorContext.tsx
+++ b/packages/open-workflow-diagram-editor/src/store/DiagramEditorContext.tsx
@@ -26,7 +26,7 @@ export type DiagramEditorContextType = {
   errors: SdkError[];
   nodes: RF.Node[];
   edges: RF.Edge[];
-  nodeIds: Set<string>;
+  taskReferences: Set<string>;
   selectedNodeId: string | null;
 
   setIsReadOnly: React.Dispatch<React.SetStateAction<boolean>>;

--- a/packages/open-workflow-diagram-editor/src/store/DiagramEditorContextProvider.tsx
+++ b/packages/open-workflow-diagram-editor/src/store/DiagramEditorContextProvider.tsx
@@ -15,7 +15,7 @@
  */
 
 import * as React from "react";
-import { buildFlatGraph, parseWorkflow } from "../core";
+import { buildFlatGraph, getTaskReferences, parseWorkflow } from "../core";
 import { DiagramEditorProps } from "../diagram-editor/DiagramEditor";
 import { DiagramEditorContext, DiagramEditorContextType } from "./DiagramEditorContext";
 import type * as RF from "@xyflow/react";
@@ -34,8 +34,8 @@ export const DiagramEditorContextProvider = (
 
   const { model, errors } = React.useMemo(() => parseWorkflow(props.content), [props.content]);
 
-  const nodeIds = React.useMemo(
-    () => (model ? new Set(buildFlatGraph(model).nodes.map((node) => node.id)) : new Set<string>()),
+  const taskReferences = React.useMemo(
+    () => (model ? getTaskReferences(buildFlatGraph(model)) : new Set<string>()),
     [model],
   );
 
@@ -59,7 +59,7 @@ export const DiagramEditorContextProvider = (
       errors,
       nodes,
       edges,
-      nodeIds,
+      taskReferences,
       selectedNodeId,
       setIsReadOnly,
       setLocale,
@@ -74,7 +74,7 @@ export const DiagramEditorContextProvider = (
       errors,
       nodes,
       edges,
-      nodeIds,
+      taskReferences,
       selectedNodeId,
       setIsReadOnly,
       setLocale,

--- a/packages/open-workflow-diagram-editor/tests-e2e/validation-error.spec.ts
+++ b/packages/open-workflow-diagram-editor/tests-e2e/validation-error.spec.ts
@@ -16,14 +16,58 @@
 
 import { test, expect } from "@playwright/test";
 
-test("renders document validation error in sidebar", async ({ page }) => {
+/* Browser tests to prove that a real ELK-laid-out diagram renders the marker and that selecting a node opens the panel holding that node's errors. */
+
+test("a workflow-level error is reachable through the side-panel trigger badge", async ({
+  page,
+}) => {
   await page.goto("/iframe.html?id=features-validation-errors--document-error");
+
+  // An unsupported DSL version belongs to no task, so it surfaces as a general error
+  const errorBadge = page.getByTestId("sidebar-errors-badge");
+  await expect(errorBadge).toBeVisible();
+  await expect(errorBadge).toHaveText("1");
+
+  const sidebar = page.locator('[data-slot="sidebar"]');
+  await expect(sidebar).toHaveAttribute("data-state", "collapsed");
+
+  await errorBadge.click();
+  await expect(sidebar).toHaveAttribute("data-state", "expanded");
 
   const errors = page.getByTestId("sidebar-errors");
   await expect(errors).toBeVisible();
   await expect(
     errors.getByText(
-      /The DSL version of the workflow '\d\.\d\.\d' does not satisfy.*supported by this SDK/,
+      /The DSL version of the workflow '\d+\.\d+\.\d+' does not satisfy.*supported by this SDK/,
     ),
   ).toBeVisible();
+});
+
+test("a nested task's error marks the child node, not its container", async ({ page }) => {
+  await page.goto("/iframe.html?id=features-validation-errors--nested-node-error");
+
+  const childNode = page.getByTestId("call-node-/do/processItems/do/chargePayment");
+  await expect(childNode).toBeVisible();
+
+  // The invalid call is nested inside the for-container. Its error must land on the child.
+  await expect(page.getByTestId("call-node-/do/processItems/do/chargePayment-error")).toBeVisible();
+
+  // ...and must NOT bubble up to the container, which is the regression this guards.
+  await expect(page.getByTestId("for-node-/do/processItems")).toBeVisible();
+  await expect(page.getByTestId("for-node-/do/processItems-error")).toHaveCount(0);
+
+  // Every error here is owned by a task, so nothing is left to count as general
+  await expect(page.getByTestId("sidebar-errors-badge")).toHaveCount(0);
+
+  await childNode.click();
+
+  // Selecting the node opens the panel on that node's details..
+  await expect(page.locator('[data-slot="sidebar"]')).toHaveAttribute("data-state", "expanded");
+  const nodeDetails = page.getByTestId("node-details");
+  await expect(nodeDetails).toBeVisible();
+
+  const errors = nodeDetails.getByTestId("sidebar-errors");
+  await expect(errors).toBeVisible();
+  await expect(errors.getByText("must have required property 'endpoint'")).toBeVisible();
+  await expect(errors.locator(".dec-sidebar-error-field")).toHaveText("with");
 });

--- a/packages/open-workflow-diagram-editor/tests-e2e/validation-error.spec.ts
+++ b/packages/open-workflow-diagram-editor/tests-e2e/validation-error.spec.ts
@@ -61,7 +61,7 @@ test("a nested task's error marks the child node, not its container", async ({ p
 
   await childNode.click();
 
-  // Selecting the node opens the panel on that node's details..
+  // Selecting the node opens the panel on that node's details.
   await expect(page.locator('[data-slot="sidebar"]')).toHaveAttribute("data-state", "expanded");
   const nodeDetails = page.getByTestId("node-details");
   await expect(nodeDetails).toBeVisible();

--- a/packages/open-workflow-diagram-editor/tests/core/graph.test.ts
+++ b/packages/open-workflow-diagram-editor/tests/core/graph.test.ts
@@ -18,6 +18,7 @@ import { describe, it, expect } from "vitest";
 import { FlatGraphNode, GraphNodeType } from "@openworkflowspec/sdk";
 import {
   getNodesByType,
+  getTaskReferences,
   fixNodesConnections,
   isTargetOutsideSourceParent,
 } from "../../src/core/graph";
@@ -77,6 +78,37 @@ describe("graph utils", () => {
 
       expect(callNodes).toHaveLength(3);
       expect(callNodes.every((node) => node.type === GraphNodeType.Call)).toBe(true);
+    });
+  });
+
+  describe("getTaskReferences", () => {
+    it("collects the taskReference of every task-backed node", () => {
+      const graph = createFlatGraph(
+        [
+          { id: "/do/call", type: GraphNodeType.Call, taskReference: "/do/0/call" },
+          { id: "/do/set", type: GraphNodeType.Set, taskReference: "/do/1/set" },
+        ] as FlatGraphNode[],
+        [],
+      );
+
+      expect(getTaskReferences(graph)).toEqual(new Set(["/do/0/call", "/do/1/set"]));
+    });
+
+    it("skips layout-only nodes, which carry no taskReference", () => {
+      const graph = createFlatGraph(
+        [
+          { id: "root-entry-node", type: GraphNodeType.Start },
+          { id: "/do/call", type: GraphNodeType.Call, taskReference: "/do/0/call" },
+          { id: "root-exit-node", type: GraphNodeType.End },
+        ] as FlatGraphNode[],
+        [],
+      );
+
+      expect(getTaskReferences(graph)).toEqual(new Set(["/do/0/call"]));
+    });
+
+    it("returns an empty set for a graph with no task nodes", () => {
+      expect(getTaskReferences(createFlatGraph([], []))).toEqual(new Set());
     });
   });
 

--- a/packages/open-workflow-diagram-editor/tests/core/validationErrors.test.ts
+++ b/packages/open-workflow-diagram-editor/tests/core/validationErrors.test.ts
@@ -19,7 +19,7 @@ import {
   isValidationError,
   getNodeErrors,
   getNodeErrorField,
-  getErrorNodeIds,
+  getErrorTaskReferences,
   getGeneralErrors,
 } from "../../src/core";
 import type { SdkError, ValidationError } from "../../src/core";
@@ -51,16 +51,18 @@ describe("isValidationError", () => {
   });
 });
 
-describe("getNodeErrors", () => {
-  const nodeIds = new Set(["/do/0/call", "/do/1/set"]);
+/* Error paths and taskReferences share one namespace: the indexed RFC 6901 pointer.
+ * Node ids are a separate, index-free namespace and never appear here. */
+const TASK_REFERENCES = new Set(["/do/0/call", "/do/1/set"]);
 
+describe("getNodeErrors", () => {
   it("returns only errors owned by the given node", () => {
     const errors: SdkError[] = [
       vErr({ path: "/do/0/call", message: "call problem" }),
       vErr({ path: "/do/1/set", message: "set problem" }),
     ];
 
-    const result = getNodeErrors(errors, "/do/0/call", nodeIds);
+    const result = getNodeErrors(errors, "/do/0/call", TASK_REFERENCES);
     expect(result).toHaveLength(1);
     expect(result[0]!.message).toBe("call problem");
   });
@@ -68,7 +70,7 @@ describe("getNodeErrors", () => {
   it("attributes field errors to their owning node", () => {
     const errors: SdkError[] = [vErr({ path: "/do/0/call/with", message: "missing endpoint" })];
 
-    const result = getNodeErrors(errors, "/do/0/call", nodeIds);
+    const result = getNodeErrors(errors, "/do/0/call", TASK_REFERENCES);
     expect(result).toHaveLength(1);
     expect(result[0]!.path).toBe("/do/0/call/with");
   });
@@ -97,22 +99,22 @@ describe("getNodeErrors", () => {
       }),
     },
   ])("filters out noise error: $description", ({ error }) => {
-    expect(getNodeErrors([error], "/do/0/call", nodeIds)).toHaveLength(0);
+    expect(getNodeErrors([error], "/do/0/call", TASK_REFERENCES)).toHaveLength(0);
   });
 
   it("keeps a missing 'catch' property error (genuine, not noise as it catch cannot be missing)", () => {
     const errors: SdkError[] = [vErr({ path: "/do/0/call", object: { missingProperty: "catch" } })];
 
-    expect(getNodeErrors(errors, "/do/0/call", nodeIds)).toHaveLength(1);
+    expect(getNodeErrors(errors, "/do/0/call", TASK_REFERENCES)).toHaveLength(1);
   });
 
   it("excludes raw (non-validation) Errors", () => {
     const errors: SdkError[] = [new Error("yaml broke")];
 
-    expect(getNodeErrors(errors, "/do/0/call", nodeIds)).toHaveLength(0);
+    expect(getNodeErrors(errors, "/do/0/call", TASK_REFERENCES)).toHaveLength(0);
   });
 
-  it("attributes a nested-child error to the longest matching node id", () => {
+  it("attributes a nested-child error to the child, not its container", () => {
     const nested = new Set(["/do/0/try", "/do/0/try/do/0/call"]);
     const errors: SdkError[] = [vErr({ path: "/do/0/try/do/0/call/with", message: "nested" })];
 
@@ -120,47 +122,58 @@ describe("getNodeErrors", () => {
     expect(getNodeErrors(errors, "/do/0/try", nested)).toHaveLength(0);
   });
 
-  it("does not match a node id that is only a string prefix without a path boundary", () => {
-    const ids = new Set(["/do/0/try"]);
+  it("attributes a container's own error to the container", () => {
+    const nested = new Set(["/do/0/try", "/do/0/try/do/0/call"]);
+    const errors: SdkError[] = [vErr({ path: "/do/0/try/catch", message: "container" })];
+
+    expect(getNodeErrors(errors, "/do/0/try", nested)).toHaveLength(1);
+    expect(getNodeErrors(errors, "/do/0/try/do/0/call", nested)).toHaveLength(0);
+  });
+
+  it("does not match a taskReference that is only a string prefix without a path boundary", () => {
+    const references = new Set(["/do/0/try"]);
     // "/do/0/tryThings" starts with "/do/0/try" as a substring but not as a path segment.
     const errors: SdkError[] = [vErr({ path: "/do/0/tryThings", message: "unrelated" })];
 
-    expect(getNodeErrors(errors, "/do/0/try", ids)).toHaveLength(0);
+    expect(getNodeErrors(errors, "/do/0/try", references)).toHaveLength(0);
   });
 });
 
 describe("getNodeErrorField", () => {
   it.each([
-    { path: "/do/0/call/with", nodeId: "/do/0/call", expected: "with" },
+    { path: "/do/0/call/with", taskReference: "/do/0/call", expected: "with" },
     {
       path: "/do/0/call/with/endpoint",
-      nodeId: "/do/0/call",
+      taskReference: "/do/0/call",
       expected: "with.endpoint",
     },
-    { path: "/do/0/call", nodeId: "/do/0/call", expected: undefined },
-    { path: "/do/1/set", nodeId: "/do/0/call", expected: undefined },
-    { path: undefined, nodeId: "/do/0/call", expected: undefined },
-  ])("path=$path nodeId=$nodeId -> $expected", ({ path, nodeId, expected }) => {
-    expect(getNodeErrorField(vErr({ path }), nodeId)).toBe(expected);
-  });
+    { path: "/do/0/call", taskReference: "/do/0/call", expected: undefined },
+    { path: "/do/1/set", taskReference: "/do/0/call", expected: undefined },
+    { path: undefined, taskReference: "/do/0/call", expected: undefined },
+  ])(
+    "path=$path taskReference=$taskReference -> $expected",
+    ({ path, taskReference, expected }) => {
+      expect(getNodeErrorField(vErr({ path }), taskReference)).toBe(expected);
+    },
+  );
 });
 
-describe("getErrorNodeIds", () => {
-  const nodeIds = new Set(["/do/0/call", "/do/1/set"]);
-
-  it("returns the set of node ids that own at least one error", () => {
+describe("getErrorTaskReferences", () => {
+  it("returns the set of taskReferences that own at least one error", () => {
     const errors: SdkError[] = [
       vErr({ path: "/do/0/call/with", message: "missing endpoint" }),
       vErr({ path: "/do/1/set", message: "set problem" }),
     ];
 
-    expect(getErrorNodeIds(errors, nodeIds)).toEqual(new Set(["/do/0/call", "/do/1/set"]));
+    expect(getErrorTaskReferences(errors, TASK_REFERENCES)).toEqual(
+      new Set(["/do/0/call", "/do/1/set"]),
+    );
   });
 
   it("excludes nodes whose only errors are noise", () => {
     const errors: SdkError[] = [vErr({ path: "/do/0/call", errorType: "#/oneOf" })];
 
-    expect(getErrorNodeIds(errors, nodeIds)).toEqual(new Set());
+    expect(getErrorTaskReferences(errors, TASK_REFERENCES)).toEqual(new Set());
   });
 
   it("ignores raw errors owned by no node", () => {
@@ -169,26 +182,24 @@ describe("getErrorNodeIds", () => {
       vErr({ path: "/document", message: "missing version" }),
     ];
 
-    expect(getErrorNodeIds(errors, nodeIds)).toEqual(new Set());
+    expect(getErrorTaskReferences(errors, TASK_REFERENCES)).toEqual(new Set());
   });
 });
 
 describe("getGeneralErrors", () => {
-  const nodeIds = new Set(["/do/0/call", "/do/1/set"]);
-
   it("includes raw Errors", () => {
     const err = new Error("yaml broke");
-    expect(getGeneralErrors([err], nodeIds)).toEqual([err]);
+    expect(getGeneralErrors([err], TASK_REFERENCES)).toEqual([err]);
   });
 
   it("includes validation errors with no path", () => {
     const errors: SdkError[] = [vErr({ errorType: "#/required", message: "missing document" })];
-    expect(getGeneralErrors(errors, nodeIds)).toEqual(errors);
+    expect(getGeneralErrors(errors, TASK_REFERENCES)).toEqual(errors);
   });
 
   it("includes validation errors whose path has no node owns (e.g. /document)", () => {
     const errors: SdkError[] = [vErr({ path: "/document", message: "missing version" })];
-    expect(getGeneralErrors(errors, nodeIds)).toEqual(errors);
+    expect(getGeneralErrors(errors, TASK_REFERENCES)).toEqual(errors);
   });
 
   it("excludes errors owned by a node", () => {
@@ -196,7 +207,7 @@ describe("getGeneralErrors", () => {
       vErr({ path: "/do/0/call", message: "owned" }),
       vErr({ path: "/do/0/call/with", message: "owned field" }),
     ];
-    expect(getGeneralErrors(errors, nodeIds)).toEqual([]);
+    expect(getGeneralErrors(errors, TASK_REFERENCES)).toEqual([]);
   });
 
   it("mixed list into node vs general", () => {
@@ -208,12 +219,12 @@ describe("getGeneralErrors", () => {
     const rawErr = new Error("yaml broke");
     const errors: SdkError[] = [owned, documentErr, rawErr];
 
-    expect(getGeneralErrors(errors, nodeIds)).toEqual([documentErr, rawErr]);
+    expect(getGeneralErrors(errors, TASK_REFERENCES)).toEqual([documentErr, rawErr]);
   });
 
   describe("additional validation error edge cases", () => {
-    it("returns each node id only once even if multiple errors belong to it", () => {
-      const nodeIds = new Set(["/do/0/call"]);
+    it("returns each taskReference only once even if multiple errors belong to it", () => {
+      const references = new Set(["/do/0/call"]);
 
       const errors: SdkError[] = [
         vErr({ path: "/do/0/call", message: "first" }),
@@ -221,11 +232,11 @@ describe("getGeneralErrors", () => {
         vErr({ path: "/do/0/call/output", message: "third" }),
       ];
 
-      expect(getErrorNodeIds(errors, nodeIds)).toEqual(new Set(["/do/0/call"]));
+      expect(getErrorTaskReferences(errors, references)).toEqual(new Set(["/do/0/call"]));
     });
 
     it("does not treat non-string missingProperty values as noise", () => {
-      const nodeIds = new Set(["/do/0/call"]);
+      const references = new Set(["/do/0/call"]);
 
       const errors: SdkError[] = [
         vErr({
@@ -236,14 +247,14 @@ describe("getGeneralErrors", () => {
         }),
       ];
 
-      const result = getNodeErrors(errors, "/do/0/call", nodeIds);
+      const result = getNodeErrors(errors, "/do/0/call", references);
 
       expect(result).toHaveLength(1);
       expect(result[0]?.object?.missingProperty).toBe(123);
     });
 
     it("keeps validation errors without an errorType", () => {
-      const nodeIds = new Set(["/do/0/call"]);
+      const references = new Set(["/do/0/call"]);
 
       const errors: SdkError[] = [
         vErr({
@@ -251,10 +262,10 @@ describe("getGeneralErrors", () => {
         }),
       ];
 
-      expect(getNodeErrors(errors, "/do/0/call", nodeIds)).toHaveLength(1);
+      expect(getNodeErrors(errors, "/do/0/call", references)).toHaveLength(1);
     });
 
-    it("returns no node errors when there are no node ids", () => {
+    it("returns no node errors when there are no taskReferences", () => {
       const errors: SdkError[] = [
         vErr({
           path: "/do/0/call",
@@ -265,7 +276,7 @@ describe("getGeneralErrors", () => {
       expect(getNodeErrors(errors, "/do/0/call", new Set())).toEqual([]);
     });
 
-    it("returns no error node ids when there are no node ids", () => {
+    it("returns no error taskReferences when there are no taskReferences", () => {
       const errors: SdkError[] = [
         vErr({
           path: "/do/0/call",
@@ -273,10 +284,10 @@ describe("getGeneralErrors", () => {
         }),
       ];
 
-      expect(getErrorNodeIds(errors, new Set())).toEqual(new Set());
+      expect(getErrorTaskReferences(errors, new Set())).toEqual(new Set());
     });
 
-    it("treats all validation errors as general when there are no node ids", () => {
+    it("treats all validation errors as general when there are no taskReferences", () => {
       const errors: SdkError[] = [
         vErr({
           path: "/do/0/call",

--- a/packages/open-workflow-diagram-editor/tests/react-flow/diagram/diagramBuilder.test.ts
+++ b/packages/open-workflow-diagram-editor/tests/react-flow/diagram/diagramBuilder.test.ts
@@ -608,7 +608,10 @@ describe("diagramBuilder", () => {
     describe("validation error highlighting", () => {
       const { model } = parseWorkflow(BASIC_VALID_WORKFLOW_JSON_TASKS);
       const baseline = buildDiagramElements(model);
-      const targetId = baseline.nodes.find((node) => node.data.task !== undefined)!.id;
+      /* Errors are matched against the node's taskReference (indexed JSON pointer) */
+      const target = baseline.nodes.find((node) => node.data.taskReference !== undefined)!;
+      const targetId = target.id;
+      const targetReference = target.data.taskReference!;
 
       it("does not set hasError on any node when no errors are passed", () => {
         const diagram = buildDiagramElements(model);
@@ -616,11 +619,10 @@ describe("diagramBuilder", () => {
       });
 
       it("sets hasError only on the node owning a error", () => {
-        const errors: SdkError[] = [{ path: targetId, message: "missing endpoint" }];
+        const errors: SdkError[] = [{ path: targetReference, message: "missing endpoint" }];
         const diagram = buildDiagramElements(model, errors);
 
-        const target = diagram.nodes.find((node) => node.id === targetId)!;
-        expect(target.data.hasError).toBe(true);
+        expect(diagram.nodes.find((node) => node.id === targetId)!.data.hasError).toBe(true);
 
         diagram.nodes
           .filter((node) => node.id !== targetId)
@@ -628,14 +630,25 @@ describe("diagramBuilder", () => {
       });
 
       it("attributes a field error to its owning node", () => {
-        const errors: SdkError[] = [{ path: `${targetId}/with`, message: "missing endpoint" }];
+        const errors: SdkError[] = [
+          { path: `${targetReference}/with`, message: "missing endpoint" },
+        ];
         const diagram = buildDiagramElements(model, errors);
 
         expect(diagram.nodes.find((node) => node.id === targetId)!.data.hasError).toBe(true);
       });
 
+      it("does not set hasError when the error path uses the node id instead of the taskReference", () => {
+        const errors: SdkError[] = [{ path: targetId, message: "missing endpoint" }];
+        const diagram = buildDiagramElements(model, errors);
+
+        diagram.nodes.forEach((node) => expect(node.data.hasError).toBeUndefined());
+      });
+
       it("does not set hasError for noise errors", () => {
-        const errors: SdkError[] = [{ path: targetId, errorType: "#/oneOf", message: "noise" }];
+        const errors: SdkError[] = [
+          { path: targetReference, errorType: "#/oneOf", message: "noise" },
+        ];
         const diagram = buildDiagramElements(model, errors);
 
         expect(diagram.nodes.find((node) => node.id === targetId)!.data.hasError).toBeUndefined();

--- a/packages/open-workflow-diagram-editor/tests/side-panel/NodeDetailsView.test.tsx
+++ b/packages/open-workflow-diagram-editor/tests/side-panel/NodeDetailsView.test.tsx
@@ -104,26 +104,29 @@ describe("NodeDetailsView", () => {
   });
 
   describe("validation errors", () => {
-    const nodeIds = new Set(["node-1"]);
+    /* Errors are attributed by taskReference (the indexed JSON pointer), not by node id */
+    const taskReference = "/do/0/getPets";
+    const taskReferences = new Set([taskReference]);
 
     it("renders the node's errors above the Properties section, with field labels", () => {
       const node = makeNode({
         label: "getPets",
+        taskReference,
         task: { call: "http", with: {} },
       });
 
       renderWithProviders(<NodeDetailsView node={node} />, {
-        nodeIds,
+        taskReferences,
         errors: [
           {
-            path: "node-1/with",
+            path: `${taskReference}/with`,
             message: "must have required property 'endpoint'",
           },
         ],
       });
 
       expect(screen.getByTestId("sidebar-errors")).toBeInTheDocument();
-      // field label derived relative to the node id
+      // field label derived relative to the node's taskReference
       const field = document.querySelector(".dec-sidebar-error-field");
       expect(field?.textContent).toBe("with");
       expect(screen.getByText("must have required property 'endpoint'")).toBeInTheDocument();
@@ -132,11 +135,11 @@ describe("NodeDetailsView", () => {
     });
 
     it("renders node details (errors only) when a task-less node has errors", () => {
-      const node = makeNode({ label: "start" }, "start");
+      const node = makeNode({ label: "start", taskReference }, "start");
 
       renderWithProviders(<NodeDetailsView node={node} />, {
-        nodeIds,
-        errors: [{ path: "node-1", message: "something is wrong" }],
+        taskReferences,
+        errors: [{ path: taskReference, message: "something is wrong" }],
       });
 
       expect(screen.getByTestId("node-details")).toBeInTheDocument();
@@ -150,16 +153,37 @@ describe("NodeDetailsView", () => {
     it("does not render the errors section when the node has no errors", () => {
       const node = makeNode({
         label: "getPets",
+        taskReference,
         task: { call: "http", with: { endpoint: "x" } },
       });
 
       renderWithProviders(<NodeDetailsView node={node} />, {
-        nodeIds,
+        taskReferences,
         errors: [],
       });
 
       expect(screen.queryByTestId("sidebar-errors")).not.toBeInTheDocument();
       expect(screen.getByText("Properties")).toBeInTheDocument();
+    });
+
+    it("attributes a nested child's error to the child, not its container", () => {
+      const containerReference = "/do/0/processItems";
+      const childReference = "/do/0/processItems/do/0/chargePayment";
+      const child = makeNode({
+        label: "chargePayment",
+        taskReference: childReference,
+        task: { call: "http", with: {} },
+      });
+
+      renderWithProviders(<NodeDetailsView node={child} />, {
+        taskReferences: new Set([containerReference, childReference]),
+        errors: [
+          { path: `${childReference}/with`, message: "must have required property 'endpoint'" },
+        ],
+      });
+
+      expect(screen.getByText("must have required property 'endpoint'")).toBeInTheDocument();
+      expect(document.querySelector(".dec-sidebar-error-field")?.textContent).toBe("with");
     });
 
     it("does not render the Source section in editable mode", () => {

--- a/packages/open-workflow-diagram-editor/tests/side-panel/SidePanelTrigger.test.tsx
+++ b/packages/open-workflow-diagram-editor/tests/side-panel/SidePanelTrigger.test.tsx
@@ -21,18 +21,18 @@ import { SidePanelTrigger } from "../../src/side-panel/SidePanelTrigger";
 import { renderWithProviders } from "../test-utils/render-helpers";
 import type { SdkError } from "../../src/core";
 
-const nodeIds = new Set(["/do/0/call", "/do/1/set"]);
+const taskReferences = new Set(["/do/0/call", "/do/1/set"]);
 
 describe("SidePanelTrigger", () => {
   it("does not render the badge when there are no general errors", () => {
-    renderWithProviders(<SidePanelTrigger />, { errors: [], nodeIds });
+    renderWithProviders(<SidePanelTrigger />, { errors: [], taskReferences });
 
     expect(screen.queryByTestId("sidebar-errors-badge")).not.toBeInTheDocument();
   });
 
   it("does not render the badge when all errors are owned by nodes", () => {
     const errors: SdkError[] = [{ path: "/do/0/call", message: "owned" }];
-    renderWithProviders(<SidePanelTrigger />, { errors, nodeIds });
+    renderWithProviders(<SidePanelTrigger />, { errors, taskReferences });
 
     expect(screen.queryByTestId("sidebar-errors-badge")).not.toBeInTheDocument();
   });
@@ -55,7 +55,7 @@ describe("SidePanelTrigger", () => {
   ])(
     "renders the badge with the general error count for $description",
     ({ errors, expectedCount }) => {
-      renderWithProviders(<SidePanelTrigger />, { errors, nodeIds });
+      renderWithProviders(<SidePanelTrigger />, { errors, taskReferences });
 
       expect(screen.getByTestId("sidebar-errors-badge")).toHaveTextContent(expectedCount);
     },
@@ -68,7 +68,7 @@ describe("SidePanelTrigger", () => {
 
     renderWithProviders(<SidePanelTrigger />, {
       errors,
-      nodeIds,
+      taskReferences,
       selectedNodeId: "/do/0/call",
       setSelectedNodeId,
     });

--- a/packages/open-workflow-diagram-editor/tests/side-panel/WorkflowInfoView.test.tsx
+++ b/packages/open-workflow-diagram-editor/tests/side-panel/WorkflowInfoView.test.tsx
@@ -70,7 +70,7 @@ describe("WorkflowInfoView", () => {
   describe("general errors", () => {
     it("renders general errors above the document section", () => {
       renderWithProviders(<WorkflowInfoView document={baseDocument} />, {
-        nodeIds: new Set(["/do/0/call"]),
+        taskReferences: new Set(["/do/0/call"]),
         errors: [
           {
             path: "/document",
@@ -89,7 +89,7 @@ describe("WorkflowInfoView", () => {
 
     it("does not render node-owned errors in the workflow view", () => {
       renderWithProviders(<WorkflowInfoView document={baseDocument} />, {
-        nodeIds: new Set(["/do/0/call"]),
+        taskReferences: new Set(["/do/0/call"]),
         errors: [{ path: "/do/0/call", message: "node-owned error" }],
       });
 
@@ -99,7 +99,7 @@ describe("WorkflowInfoView", () => {
 
     it("does not render the errors section when there are no general errors", () => {
       renderWithProviders(<WorkflowInfoView document={baseDocument} />, {
-        nodeIds: new Set(),
+        taskReferences: new Set(),
         errors: [],
       });
 
@@ -167,7 +167,7 @@ describe("WorkflowInfoView", () => {
 
     it("renders both general validation errors and raw errors together", () => {
       renderWithProviders(<WorkflowInfoView document={baseDocument} />, {
-        nodeIds: new Set(["/do/0/call"]),
+        taskReferences: new Set(["/do/0/call"]),
         errors: [{ path: "/document", message: "Missing version" }, new Error("Invalid workflow")],
       });
 

--- a/packages/open-workflow-diagram-editor/tests/test-utils/render-helpers.tsx
+++ b/packages/open-workflow-diagram-editor/tests/test-utils/render-helpers.tsx
@@ -38,7 +38,7 @@ export const createMockContextValue = (
   errors: [],
   nodes: [],
   edges: [],
-  nodeIds: new Set(),
+  taskReferences: new Set(),
   selectedNodeId: null,
   setIsReadOnly: noop,
   setLocale: noop,


### PR DESCRIPTION
Closes: https://github.com/open-workflow-specification/editor/issues/303

### Summary
`sdk-typescript alpha5+` split node ids into 2 identifiers, it changed ids to name based ids and added a new `taskReference` which is an index RFC 6901 pointer. `ValidationError.path` is an indexed pointer and lives in `taskReference` which broke the existing validation logic

### Changes
- Validation errors now use the `taskReference`
- `diagramBuilder` checks the `taskReference` 
- Replace `nodeIds` with taskReferences
- Improvement, nested node errors now render correctly on the nested node
- Add unit tests - the `diagramBuilder` test read a node id and then fabricated an error path from it so it didnt fail on schema change, tests added updated
- Add e2e tests to confirm error badges are rendered 