### PR TITLE
NO-ISSUE: Fix Serverless leftovers to Open Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To build and run the editor locally, you will need:
 
 ## Getting Started with the Diagram Editor
 
-See the [Getting Started guide](./packages/serverless-workflow-diagram-editor/README.md#getting-started) for installation and usage instructions for the Serverless Workflow Diagram Editor React component.
+See the [Getting Started guide](./packages/open-workflow-diagram-editor/README.md#getting-started) for installation and usage instructions for the Open Workflow Diagram Editor React component.
 
 ## Building the Project
 

--- a/examples/vanilla-web-component/README.md
+++ b/examples/vanilla-web-component/README.md
@@ -40,12 +40,12 @@ The wrapper in `src/diagram-editor-element.ts` defines a custom element `<openwo
 
 ### HTMLElement attributes
 
-| Attribute / Property | Type                            | Default    | Description                                              |
-| -------------------- | ------------------------------- | ---------- | -------------------------------------------------------- |
-| `content` (property) | `string`                        | -          | Serverless Workflow specification in YAML or JSON format |
-| `locale`             | `string`                        | -          | Language locale for the editor UI                        |
-| `color-mode`         | `'light' \| 'dark' \| 'system'` | `"system"` | Color theme for the editor                               |
-| `read-only`          | boolean                         | -          | Enable read-only mode to prevent editing                 |
+| Attribute / Property | Type                            | Default    | Description                                        |
+| -------------------- | ------------------------------- | ---------- | -------------------------------------------------- |
+| `content` (property) | `string`                        | -          | Open Workflow specification in YAML or JSON format |
+| `locale`             | `string`                        | -          | Language locale for the editor UI                  |
+| `color-mode`         | `'light' \| 'dark' \| 'system'` | `"system"` | Color theme for the editor                         |
+| `read-only`          | boolean                         | -          | Enable read-only mode to prevent editing           |
 
 ### Usage
 

--- a/packages/open-workflow-diagram-editor/README.md
+++ b/packages/open-workflow-diagram-editor/README.md
@@ -76,12 +76,12 @@ function App() {
 
 ### Props
 
-| Prop         | Type                            | Required | Default    | Description                                              |
-| ------------ | ------------------------------- | -------- | ---------- | -------------------------------------------------------- |
-| `content`    | `string`                        | Yes      | -          | Serverless Workflow specification in YAML or JSON format |
-| `isReadOnly` | `boolean`                       | Yes      | -          | Enable read-only mode to prevent editing                 |
-| `locale`     | `string`                        | Yes      | -          | Language locale for the editor UI                        |
-| `colorMode`  | `'light' \| 'dark' \| 'system'` | No       | `'system'` | Color theme for the editor                               |
+| Prop         | Type                            | Required | Default    | Description                                        |
+| ------------ | ------------------------------- | -------- | ---------- | -------------------------------------------------- |
+| `content`    | `string`                        | Yes      | -          | Open Workflow specification in YAML or JSON format |
+| `isReadOnly` | `boolean`                       | Yes      | -          | Enable read-only mode to prevent editing           |
+| `locale`     | `string`                        | Yes      | -          | Language locale for the editor UI                  |
+| `colorMode`  | `'light' \| 'dark' \| 'system'` | No       | `'system'` | Color theme for the editor                         |
 
 ## Development
 

--- a/packages/open-workflow-diagram-editor/stories/examples/workflows/call-asyncapi-subscribe-consume-forever-foreach.yaml
+++ b/packages/open-workflow-diagram-editor/stories/examples/workflows/call-asyncapi-subscribe-consume-forever-foreach.yaml
@@ -36,7 +36,7 @@ do:
                   emit:
                     event:
                       with:
-                        source: https://serverlessworkflow.io/samples
+                        source: https://open-workflow-specification.org/samples
                         type: io.serverlessworkflow.samples.asyncapi.message.consumed.v1
                         data:
                           message: "${ $message }"

--- a/packages/open-workflow-diagram-editor/stories/examples/workflows/call-custom-function-cataloged.yaml
+++ b/packages/open-workflow-diagram-editor/stories/examples/workflows/call-custom-function-cataloged.yaml
@@ -20,7 +20,7 @@ document:
   version: "0.1.0"
 do:
   - log:
-      call: https://raw.githubusercontent.com/serverlessworkflow/catalog/main/functions/log/1.0.0/function.yaml
+      call: https://raw.githubusercontent.com/open-workflow-specification/catalog/main/functions/log/1.0.0/function.yaml
       with:
         message: Hello, world!
         level: information

--- a/packages/open-workflow-diagram-editor/stories/examples/workflows/raise-reusable.yaml
+++ b/packages/open-workflow-diagram-editor/stories/examples/workflows/raise-reusable.yaml
@@ -21,7 +21,7 @@ document:
 use:
   errors:
     notImplemented:
-      type: https://serverlessworkflow.io/errors/not-implemented
+      type: https://open-workflow-specification.org/errors/not-implemented
       status: 500
       title: Not Implemented
       detail: ${ "The workflow '\( $workflow.definition.document.name ):\( $workflow.definition.document.version )' is a work in progress and cannot be run yet" }

--- a/packages/open-workflow-diagram-editor/stories/examples/workflows/try-catch-retry-reusable.yaml
+++ b/packages/open-workflow-diagram-editor/stories/examples/workflows/try-catch-retry-reusable.yaml
@@ -39,6 +39,6 @@ do:
       catch:
         errors:
           with:
-            type: https://serverlessworkflow.io/spec/1.0.0/errors/communication
+            type: https://open-workflow-specification.org/spec/1.0.0/errors/communication
             status: 503
         retry: default

--- a/packages/open-workflow-diagram-editor/stories/examples/workflows/try-catch-then.yaml
+++ b/packages/open-workflow-diagram-editor/stories/examples/workflows/try-catch-then.yaml
@@ -29,7 +29,7 @@ do:
       catch:
         errors:
           with:
-            type: https://serverlessworkflow.io/spec/1.0.0/errors/communication
+            type: https://open-workflow-specification.org/spec/1.0.0/errors/communication
             status: 404
         as: error
         do:

--- a/packages/open-workflow-diagram-editor/stories/introduction/Welcome.mdx
+++ b/packages/open-workflow-diagram-editor/stories/introduction/Welcome.mdx
@@ -20,7 +20,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 # Welcome to the Diagram Editor
 
-The **Open Workflow Diagram Editor** is the official visual editor for the [CNCF Open Workflow Specification](https://serverlessworkflow.io). 
+The **Open Workflow Diagram Editor** is the official visual editor for the [CNCF Open Workflow Specification](https://open-workflow-specification.org). 
 It provides an intuitive, interactive way to design, visualize, and understand open workflow definitions.
 
 ## What is this editor?
@@ -49,7 +49,7 @@ Explore the **Examples** section in the sidebar to see the editor in action with
 ## Relevant Resources
 
 - [Cloud Native Computing Foundation (CNCF)](https://www.cncf.io)
-- [CNCF Open Workflow Specification](https://serverlessworkflow.io)
+- [CNCF Open Workflow Specification](https://open-workflow-specification.org)
 - [Open Workflow TypeScript SDK](https://github.com/open-workflow-specification/sdk-typescript)
 - [GitHub Repository](https://github.com/open-workflow-specification/editor)
 

--- a/packages/open-workflow-diagram-editor/stories/introduction/Welcome.mdx
+++ b/packages/open-workflow-diagram-editor/stories/introduction/Welcome.mdx
@@ -20,7 +20,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 # Welcome to the Diagram Editor
 
-The **Open Workflow Diagram Editor** is the official visual editor for the [CNCF Open Workflow Specification](https://open-workflow-specification.org). 
+The **Open Workflow Diagram Editor** is the official visual editor for the [CNCF Open Workflow Specification](https://open-workflow-specification.org).
 It provides an intuitive, interactive way to design, visualize, and understand open workflow definitions.
 
 ## What is this editor?

--- a/packages/open-workflow-diagram-editor/stories/use-cases/workflows/managing-ev-charging-stations.yaml
+++ b/packages/open-workflow-diagram-editor/stories/use-cases/workflows/managing-ev-charging-stations.yaml
@@ -192,7 +192,7 @@ do:
   - raiseUnsupportedEventError:
       raise:
         error:
-          type: https://serverlessworkflow.io/spec/1.0.0/errors/runtime
+          type: https://open-workflow-specification.org/spec/1.0.0/errors/runtime
           status: 400
           title: Unsupported Event
           detail: ${ "The specified station event '\($context.event.type)' is not supported in this context" }

--- a/packages/open-workflow-diagram-editor/stories/use-cases/workflows/managing-github-issues.yaml
+++ b/packages/open-workflow-diagram-editor/stories/use-cases/workflows/managing-github-issues.yaml
@@ -42,7 +42,7 @@ do:
             emit:
               event:
                 with:
-                  source: https://serverlessworkflow.io
+                  source: https://open-workflow-specification.org
                   type: com.github.events.issues.assignedToDevTeam.v1
                   data:
                     issue: ${ .issue }
@@ -79,7 +79,7 @@ do:
             emit:
               event:
                 with:
-                  source: https://serverlessworkflow.io
+                  source: https://open-workflow-specification.org
                   type: com.github.events.issues.assignedToQATeam.v1
                   data:
                     issue: ${ $context.issue }
@@ -104,7 +104,7 @@ do:
             emit:
               event:
                 with:
-                  source: https://serverlessworkflow.io
+                  source: https://open-workflow-specification.org
                   type: com.github.events.issues.pendingReview.v1
                   data:
                     issue: ${ $context.issue }
@@ -138,7 +138,7 @@ do:
             emit:
               event:
                 with:
-                  source: https://serverlessworkflow.io
+                  source: https://open-workflow-specification.org
                   type: com.github.events.issues.evaluateReview.v1
                   data:
                     issue: ${ $context.issue }
@@ -180,7 +180,7 @@ do:
                   emit:
                     event:
                       with:
-                        source: https://serverlessworkflow.io
+                        source: https://open-workflow-specification.org
                         type: com.github.events.issues.closed.v1
                         data:
                           issue: ${ $context.issue }
@@ -190,7 +190,7 @@ do:
   - raiseUnsupportedActionError:
       raise:
         error:
-          type: https://serverlessworkflow.io/spec/1.0.0/errors/runtime
+          type: https://open-workflow-specification.org/spec/1.0.0/errors/runtime
           status: 400
           title: Unsupported Action
           detail: The specified action is not supported in this context
@@ -199,7 +199,7 @@ do:
   - raiseAssignedDevCannotBeReviewer:
       raise:
         error:
-          type: https://serverlessworkflow.io/spec/1.0.0/errors/runtime
+          type: https://open-workflow-specification.org/spec/1.0.0/errors/runtime
           status: 400
           title: Invalid Reviewer
           detail: The developer that has performed the work associated with the issue cannot be the reviewer of its own work


### PR DESCRIPTION
There where some `Severless` leftovers, and this PR is to rename to `Open Workflow`.
I also fixed some GH url inside workflows.

**Note:** the licenes check will be fixed by https://github.com/open-workflow-specification/editor/pull/304