### PR TITLE
fix #283 - feat: Reduce warnings in build and test logs

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -4,7 +4,10 @@
   "rules": {
     "react/react-in-jsx-scope": "off",
     "typescript/no-unused-vars": ["warn", { "varsIgnorePattern": "^_" }],
-    "typescript/no-explicit-any": "warn"
+    "typescript/no-explicit-any": "warn",
+    "jsx-a11y/prefer-tag-over-role": "off",
+    "jsx-a11y/click-events-have-key-events": "off",
+    "jsx-a11y/no-noninteractive-element-interactions": "off"
   },
   "ignorePatterns": ["**/dist/", "**/dist-storybook/", "**/node_modules/"],
   "options": {

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://oxc.rs/schema/oxlintrc.json",
-  "plugins": ["react", "typescript", "import", "jsx-a11y"],
+  "plugins": ["react", "typescript", "import"],
   "rules": {
     "react/react-in-jsx-scope": "off",
     "typescript/no-unused-vars": ["warn", { "varsIgnorePattern": "^_" }],

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://oxc.rs/schema/oxlintrc.json",
-  "plugins": ["react", "typescript", "import"],
+  "plugins": ["react", "typescript", "import", "jsx-a11y"],
   "rules": {
     "react/react-in-jsx-scope": "off",
     "typescript/no-unused-vars": ["warn", { "varsIgnorePattern": "^_" }],

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -6,5 +6,8 @@
     "typescript/no-unused-vars": ["warn", { "varsIgnorePattern": "^_" }],
     "typescript/no-explicit-any": "warn"
   },
-  "ignorePatterns": ["**/dist/", "**/dist-storybook/", "**/node_modules/"]
+  "ignorePatterns": ["**/dist/", "**/dist-storybook/", "**/node_modules/"],
+  "options": {
+    "denyWarnings": true
+  }
 }

--- a/examples/vanilla-web-component/vite.config.ts
+++ b/examples/vanilla-web-component/vite.config.ts
@@ -26,5 +26,6 @@ export default defineConfig({
   build: {
     emptyOutDir: false,
     sourcemap: true,
+    chunkSizeWarningLimit: 5000,
   },
 });

--- a/examples/vanilla-web-component/vite.config.ts
+++ b/examples/vanilla-web-component/vite.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
   build: {
     emptyOutDir: false,
     sourcemap: true,
+    // Raised to 5000 to suppress chunk size warning
     chunkSizeWarningLimit: 5000,
   },
 });

--- a/packages/i18n/.oxfmtrc.json
+++ b/packages/i18n/.oxfmtrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../.oxfmtrc.json"]
+}

--- a/packages/i18n/.oxlintrc.json
+++ b/packages/i18n/.oxlintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../.oxlintrc.json"]
+}

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -28,7 +28,10 @@
   "scripts": {
     "clean": "rimraf ./dist",
     "build:dev": "pnpm clean && tsc -p tsconfig.json && vite build",
-    "build:prod": "pnpm run build:dev && pnpm test",
+    "build:prod": "pnpm lint && pnpm run build:dev && pnpm test",
+    "lint": "oxlint --config .oxlintrc.json src/ tests/",
+    "format": "oxfmt --config .oxfmtrc.json",
+    "format:check": "oxfmt --config .oxfmtrc.json --check",
     "test": "vitest run"
   },
   "devDependencies": {
@@ -37,6 +40,8 @@
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
     "rimraf": "catalog:",

--- a/packages/open-workflow-diagram-editor/src/components/ui/combobox.tsx
+++ b/packages/open-workflow-diagram-editor/src/components/ui/combobox.tsx
@@ -267,7 +267,7 @@ function ComboboxChip({
   );
 }
 
-function ComboboxChipsInput({ className, children, ...props }: ComboboxPrimitive.Input.Props) {
+function ComboboxChipsInput({ className, ...props }: ComboboxPrimitive.Input.Props) {
   return (
     <ComboboxPrimitive.Input
       data-slot="combobox-chip-input"

--- a/packages/open-workflow-diagram-editor/stories/README.md
+++ b/packages/open-workflow-diagram-editor/stories/README.md
@@ -25,6 +25,7 @@ This directory contains Storybook stories and documentation.
 - **`examples/`** - Open Workflow Specification examples
 - **`use-cases/`** - Real-world use case examples
 - **`assets/`** - Images and media files used in stories
+- **`helpers.ts`** - Shared utilities for creating stories
 
 ## Running Storybook
 

--- a/packages/open-workflow-diagram-editor/stories/examples/Examples.stories.tsx
+++ b/packages/open-workflow-diagram-editor/stories/examples/Examples.stories.tsx
@@ -16,6 +16,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { DiagramEditor } from "../features/DiagramEditor";
+import { createWorkflowStory } from "../helpers";
 import * as workflows from "./index";
 
 const meta = {
@@ -33,25 +34,6 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 // Constants for shared configuration
-const DEFAULT_STORY_ARGS = {
-  isReadOnly: true,
-  locale: "en" as const,
-} as const;
-
-/**
- * Factory function to create workflow story configurations
- * @param workflowContent - The YAML workflow content to display
- * @returns Story configuration object
- */
-const createWorkflowStory = (workflowContent: string): Story => {
-  return {
-    args: {
-      ...DEFAULT_STORY_ARGS,
-      content: workflowContent,
-    },
-  };
-};
-
 // Story definitions using the factory function
 export const AccumulateRoomReadings: Story = createWorkflowStory(workflows.accumulateRoomReadings);
 export const AuthenticationOAuth2: Story = createWorkflowStory(workflows.authenticationOAuth2);

--- a/packages/open-workflow-diagram-editor/stories/features/DiagramEditor.stories.tsx
+++ b/packages/open-workflow-diagram-editor/stories/features/DiagramEditor.stories.tsx
@@ -15,7 +15,7 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
-
+import { createWorkflowStory } from "../helpers";
 import { DiagramEditor } from "./DiagramEditor";
 
 const workflowExample = `document:
@@ -107,13 +107,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Component: Story = {
-  args: {
-    isReadOnly: true,
-    locale: "en",
-    content: workflowExample,
-  },
-};
+export const Component: Story = createWorkflowStory(workflowExample);
 
 /* The two stories below each isolate ONE piece of spec syntax the editor must accept,
  * and both must render clean (no error badge).
@@ -147,19 +141,7 @@ do:
               roomId: \${ .roomid }`;
 
 /* A URI is an RFC 3986 URI-reference, so a relative one is valid and must not error. */
-export const RelativeUriEndpoint: Story = {
-  args: {
-    isReadOnly: true,
-    locale: "en",
-    content: relativeUriEndpointExample,
-  },
-};
+export const RelativeUriEndpoint: Story = createWorkflowStory(relativeUriEndpointExample);
 
 /* `source` is optional when emitting (runtimes generate it from the workflow) — so omitting it must not error. */
-export const EmitWithoutSource: Story = {
-  args: {
-    isReadOnly: true,
-    locale: "en",
-    content: emitWithoutSourceExample,
-  },
-};
+export const EmitWithoutSource: Story = createWorkflowStory(emitWithoutSourceExample);

--- a/packages/open-workflow-diagram-editor/stories/features/DiagramEditorDragNDrop.tsx
+++ b/packages/open-workflow-diagram-editor/stories/features/DiagramEditorDragNDrop.tsx
@@ -71,9 +71,6 @@ export const DiagramEditorDragNDrop = (props: Omit<DiagramEditorProps, "content"
     e.target.value = "";
   };
 
-  /* TODO: Remove this console log when the DiagramEditor is using the content from the param  */
-  console.log("### content updated:\n", content);
-
   return (
     <div style={{ height: "100vh" }}>
       <div

--- a/packages/open-workflow-diagram-editor/stories/features/DiagramEditorErrorBoundary.stories.tsx
+++ b/packages/open-workflow-diagram-editor/stories/features/DiagramEditorErrorBoundary.stories.tsx
@@ -18,6 +18,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { DiagramEditorErrorBoundary } from "../../src/diagram-editor/error-pages/DiagramEditorErrorBoundary";
 import { ColorMode } from "../../src/types/colorMode";
 import { useResolvedColorMode } from "../../src/hooks/useResolvedColorMode";
+import { spyOn } from "storybook/test";
 
 type DiagramEditorErrorBoundaryProps = {
   title?: string;
@@ -29,11 +30,29 @@ type DiagramEditorErrorBoundaryStoryProps = DiagramEditorErrorBoundaryProps & {
   colorMode?: ColorMode;
 };
 
-const ThrowError = ({ message = "Test error message" }: { message?: string }) => {
+const DEFAULT_ERROR_MESSAGE = "Test error message";
+const CUSTOM_ERROR_MESSAGE = "Custom error details in snippet";
+
+const ThrowError = ({ message = DEFAULT_ERROR_MESSAGE }: { message?: string }) => {
   throw new Error(message);
 };
 
 const meta = {
+  beforeEach: () => {
+    const originalConsoleError = console.error;
+
+    const consoleErrorSpy = spyOn(console, "error").mockImplementation((...args) => {
+      const error = args[1];
+
+      if (error instanceof Error && (error.message===DEFAULT_ERROR_MESSAGE || error.message===CUSTOM_ERROR_MESSAGE)) {
+        return;
+      }
+
+      originalConsoleError(...args);
+    });
+
+    return () => consoleErrorSpy.mockRestore();
+  },
   title: "Features/DiagramEditorErrorBoundary",
   component: DiagramEditorErrorBoundary,
   tags: ["autodocs"],
@@ -78,6 +97,6 @@ export const WithErrorCustomMessage: Story = {
   args: {
     title: "Custom Error Title",
     message: "This is a custom error message",
-    children: <ThrowError message="Custom error details in snippet" />,
+    children: <ThrowError message={CUSTOM_ERROR_MESSAGE} />,
   },
 };

--- a/packages/open-workflow-diagram-editor/stories/features/ValidationErrors.stories.tsx
+++ b/packages/open-workflow-diagram-editor/stories/features/ValidationErrors.stories.tsx
@@ -16,6 +16,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { DiagramEditor } from "./DiagramEditor";
+import { createWorkflowStory } from "../helpers";
 
 const meta = {
   title: "Features/Validation Errors",
@@ -30,15 +31,6 @@ const meta = {
 
 export default meta;
 type Story = StoryObj<typeof meta>;
-
-const DEFAULT_STORY_ARGS = {
-  isReadOnly: true,
-  locale: "en" as const,
-} as const;
-
-const createWorkflowStory = (content: string): Story => ({
-  args: { ...DEFAULT_STORY_ARGS, content },
-});
 
 export const DocumentError: Story = createWorkflowStory(
   `

--- a/packages/open-workflow-diagram-editor/stories/helpers.ts
+++ b/packages/open-workflow-diagram-editor/stories/helpers.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021-Present The Open Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { StoryObj } from "@storybook/react-vite";
+import type { DiagramEditor } from "./features/DiagramEditor";
+
+type Story = StoryObj<typeof DiagramEditor>;
+
+const DEFAULT_STORY_ARGS = {
+  isReadOnly: true,
+  locale: "en" as const,
+} as const;
+
+/**
+ * Creates a workflow story with default configuration and play function.
+ * 
+ * @param workflowContent - The workflow YAML/JSON content to display
+ * @returns A configured Story object
+ */
+export const createWorkflowStory = (workflowContent: string): Story => {
+  return {
+    args: {
+      ...DEFAULT_STORY_ARGS,
+      content: workflowContent,
+    },
+    play: async ({ canvas }) => {
+      // Wait for the start node to be rendered to ensure all async state updates are complete
+      await canvas.findByTestId("start-node-root-entry-node");
+    },
+  };
+};

--- a/packages/open-workflow-diagram-editor/stories/use-cases/UseCases.stories.tsx
+++ b/packages/open-workflow-diagram-editor/stories/use-cases/UseCases.stories.tsx
@@ -16,6 +16,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { DiagramEditor } from "../features/DiagramEditor";
+import { createWorkflowStory } from "../helpers";
 import * as workflows from "./index";
 
 const meta = {
@@ -31,20 +32,6 @@ const meta = {
 
 export default meta;
 type Story = StoryObj<typeof meta>;
-
-const DEFAULT_STORY_ARGS = {
-  isReadOnly: true,
-  locale: "en" as const,
-} as const;
-
-const createWorkflowStory = (workflowContent: string): Story => {
-  return {
-    args: {
-      ...DEFAULT_STORY_ARGS,
-      content: workflowContent,
-    },
-  };
-};
 
 export const AutomatedDataBackup: Story = createWorkflowStory(workflows.automatedDataBackup);
 export const ManagingEVChargingStations: Story = createWorkflowStory(

--- a/packages/open-workflow-diagram-editor/tests/core/taskDetails.test.ts
+++ b/packages/open-workflow-diagram-editor/tests/core/taskDetails.test.ts
@@ -271,7 +271,7 @@ describe("getTaskDetails", () => {
         output: { as: "${ .output }" },
         export: { as: "${ .export }" },
         timeout: "PT5M",
-        // eslint-disable-next-line unicorn/no-thenable -- then is a Open Workflow Spec field
+        // eslint-disable-next-line unicorn/no-thenable -- then is an Open Workflow Spec field
         then: "next",
       }),
     );

--- a/packages/open-workflow-diagram-editor/tests/core/taskDetails.test.ts
+++ b/packages/open-workflow-diagram-editor/tests/core/taskDetails.test.ts
@@ -271,7 +271,7 @@ describe("getTaskDetails", () => {
         output: { as: "${ .output }" },
         export: { as: "${ .export }" },
         timeout: "PT5M",
-        // eslint-disable-next-line unicorn/no-thenable -- then is a Serverless Workflow Spec field
+        // eslint-disable-next-line unicorn/no-thenable -- then is a Open Workflow Spec field
         then: "next",
       }),
     );

--- a/packages/open-workflow-diagram-editor/tests/core/taskDetails.test.ts
+++ b/packages/open-workflow-diagram-editor/tests/core/taskDetails.test.ts
@@ -271,6 +271,7 @@ describe("getTaskDetails", () => {
         output: { as: "${ .output }" },
         export: { as: "${ .export }" },
         timeout: "PT5M",
+        // eslint-disable-next-line unicorn/no-thenable -- then is a Serverless Workflow Spec field
         then: "next",
       }),
     );

--- a/packages/open-workflow-diagram-editor/tests/react-flow/edges/Edges.test.tsx
+++ b/packages/open-workflow-diagram-editor/tests/react-flow/edges/Edges.test.tsx
@@ -50,17 +50,19 @@ describe("React Flow custom edge types", () => {
     const Component = component;
     const { container } = render(
       <RF.ReactFlowProvider>
-        <Component
-          id={"n1-n2"}
-          source={"n1"}
-          target={"n2"}
-          sourceX={0}
-          sourceY={0}
-          targetX={0}
-          targetY={0}
-          sourcePosition={RF.Position.Left}
-          targetPosition={RF.Position.Left}
-        />
+        <svg>
+          <Component
+            id={"n1-n2"}
+            source={"n1"}
+            target={"n2"}
+            sourceX={0}
+            sourceY={0}
+            targetX={0}
+            targetY={0}
+            sourcePosition={RF.Position.Left}
+            targetPosition={RF.Position.Left}
+          />
+        </svg>
       </RF.ReactFlowProvider>,
     );
     const path = container.querySelector("path.edge-line");
@@ -158,18 +160,20 @@ describe("React Flow custom edge types", () => {
     ({ component: Component, selected, shouldHaveSelected, expectedClasses }) => {
       const { container } = render(
         <RF.ReactFlowProvider>
-          <Component
-            id={"n1-n2"}
-            source={"n1"}
-            target={"n2"}
-            sourceX={0}
-            sourceY={0}
-            targetX={0}
-            targetY={0}
-            sourcePosition={RF.Position.Left}
-            targetPosition={RF.Position.Left}
-            selected={selected}
-          />
+          <svg>
+            <Component
+              id={"n1-n2"}
+              source={"n1"}
+              target={"n2"}
+              sourceX={0}
+              sourceY={0}
+              targetX={0}
+              targetY={0}
+              sourcePosition={RF.Position.Left}
+              targetPosition={RF.Position.Left}
+              selected={selected}
+            />
+          </svg>
         </RF.ReactFlowProvider>,
       );
       const path = container.querySelector("path.edge-line");
@@ -188,24 +192,27 @@ describe("React Flow custom edge types", () => {
   it("matches snapshot with waypoints", () => {
     const { container } = render(
       <RF.ReactFlowProvider>
-        <DefaultEdge
-          id={"n1-n2"}
-          source={"n1"}
-          target={"n2"}
-          sourceX={0}
-          sourceY={0}
-          targetX={0}
-          targetY={0}
-          sourcePosition={RF.Position.Left}
-          targetPosition={RF.Position.Left}
-          data={{
-            wayPoints: [{ x: 50, y: 50 }],
-          }}
-        />
+        <svg>
+          <DefaultEdge
+            id={"n1-n2"}
+            source={"n1"}
+            target={"n2"}
+            sourceX={0}
+            sourceY={0}
+            targetX={0}
+            targetY={0}
+            sourcePosition={RF.Position.Left}
+            targetPosition={RF.Position.Left}
+            data={{
+              wayPoints: [{ x: 50, y: 50 }],
+            }}
+          />
+        </svg>
       </RF.ReactFlowProvider>,
     );
 
-    expect(container.firstChild).toMatchSnapshot();
+    const svg = container.querySelector("svg");
+    expect(svg?.firstChild).toMatchSnapshot();
   });
 });
 
@@ -391,18 +398,20 @@ describe("EdgeLabel component", () => {
     ])("$description", ({ component: Component, data, selector }) => {
       const { container } = render(
         <RF.ReactFlowProvider>
-          <Component
-            id="e1"
-            source="n1"
-            target="n2"
-            sourceX={0}
-            sourceY={0}
-            targetX={100}
-            targetY={100}
-            sourcePosition={RF.Position.Right}
-            targetPosition={RF.Position.Left}
-            data={data}
-          />
+          <svg>
+            <Component
+              id="e1"
+              source="n1"
+              target="n2"
+              sourceX={0}
+              sourceY={0}
+              targetX={100}
+              targetY={100}
+              sourcePosition={RF.Position.Right}
+              targetPosition={RF.Position.Left}
+              data={data}
+            />
+          </svg>
         </RF.ReactFlowProvider>,
       );
 
@@ -494,7 +503,7 @@ describe("EdgeLabel positioning", () => {
       targetX: 100,
       targetY: 40,
       data: { label: "Test" },
-    });
+});
 
     expect(JSON.stringify(result)).toContain(`translate(${labelX}px,${labelY}px)`);
   });
@@ -557,19 +566,21 @@ describe("EdgeLabel z-index behavior", () => {
       ({ component: Component, edgeClass, selected }) => {
         const { container } = render(
           <RF.ReactFlowProvider>
-            <Component
-              id="e1"
-              source="n1"
-              target="n2"
-              sourceX={0}
-              sourceY={0}
-              targetX={100}
-              targetY={100}
-              sourcePosition={RF.Position.Right}
-              targetPosition={RF.Position.Left}
-              data={{ label: "Test Label" }}
-              selected={selected}
-            />
+            <svg>
+              <Component
+                id="e1"
+                source="n1"
+                target="n2"
+                sourceX={0}
+                sourceY={0}
+                targetX={100}
+                targetY={100}
+                sourcePosition={RF.Position.Right}
+                targetPosition={RF.Position.Left}
+                data={{ label: "Test Label" }}
+                selected={selected}
+              />
+            </svg>
           </RF.ReactFlowProvider>,
         );
 

--- a/packages/open-workflow-diagram-editor/tests/react-flow/edges/Edges.test.tsx
+++ b/packages/open-workflow-diagram-editor/tests/react-flow/edges/Edges.test.tsx
@@ -212,7 +212,8 @@ describe("React Flow custom edge types", () => {
     );
 
     const svg = container.querySelector("svg");
-    expect(svg?.firstChild).toMatchSnapshot();
+    expect(svg).not.toBeNull();
+    expect(svg!.firstChild).toMatchSnapshot();
   });
 });
 
@@ -503,7 +504,7 @@ describe("EdgeLabel positioning", () => {
       targetX: 100,
       targetY: 40,
       data: { label: "Test" },
-});
+    });
 
     expect(JSON.stringify(result)).toContain(`translate(${labelX}px,${labelY}px)`);
   });

--- a/packages/open-workflow-diagram-editor/tests/side-panel/NodeDetailsView.test.tsx
+++ b/packages/open-workflow-diagram-editor/tests/side-panel/NodeDetailsView.test.tsx
@@ -36,7 +36,7 @@ describe("NodeDetailsView", () => {
       task: {
         call: "http",
         with: { endpoint: "https://api.example.com" },
-        // eslint-disable-next-line unicorn/no-thenable -- then is a Open Workflow Spec field
+        // eslint-disable-next-line unicorn/no-thenable -- then is an Open Workflow Spec field
         then: "continue",
       },
     });

--- a/packages/open-workflow-diagram-editor/tests/side-panel/NodeDetailsView.test.tsx
+++ b/packages/open-workflow-diagram-editor/tests/side-panel/NodeDetailsView.test.tsx
@@ -36,7 +36,7 @@ describe("NodeDetailsView", () => {
       task: {
         call: "http",
         with: { endpoint: "https://api.example.com" },
-        // eslint-disable-next-line unicorn/no-thenable -- then is a Serverless Workflow Spec field
+        // eslint-disable-next-line unicorn/no-thenable -- then is a Open Workflow Spec field
         then: "continue",
       },
     });

--- a/packages/open-workflow-diagram-editor/tests/side-panel/NodeDetailsView.test.tsx
+++ b/packages/open-workflow-diagram-editor/tests/side-panel/NodeDetailsView.test.tsx
@@ -36,6 +36,7 @@ describe("NodeDetailsView", () => {
       task: {
         call: "http",
         with: { endpoint: "https://api.example.com" },
+        // eslint-disable-next-line unicorn/no-thenable -- then is a Serverless Workflow Spec field
         then: "continue",
       },
     });

--- a/packages/open-workflow-diagram-editor/vitest.config.ts
+++ b/packages/open-workflow-diagram-editor/vitest.config.ts
@@ -21,8 +21,7 @@ import { defineConfig } from "vitest/config";
 import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
 import { playwright } from "@vitest/browser-playwright";
 
-const dirname =
-  typeof __dirname !== "undefined" ? __dirname : path.dirname(fileURLToPath(import.meta.url));
+const dirname = import.meta.dirname ?? path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [tailwindcss()],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,6 +237,12 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.4(@types/react@19.2.18)
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.61.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.76.0
       react:
         specifier: 'catalog:'
         version: 19.2.8


### PR DESCRIPTION
Closes https://github.com/open-workflow-specification/editor/issues/283

### Description

The open-workflow-diagram-editor build currently produces a large number of warnings, like for React `act(...)`, accessibility, and lint warnings.

Example job: https://github.com/open-workflow-specification/editor/actions/runs/30353445942/job/90256050921?pr=282

**Log snippet:**
```
packages/open-workflow-diagram-editor build:prod: This ensures that you're testing the behavior the user would see in the browser. Learn more at https://react.dev/link/wrap-tests-with-act
packages/open-workflow-diagram-editor build:prod: stderr | stories/examples/Examples.stories.tsx > Accumulate Room Readings
packages/open-workflow-diagram-editor build:prod: An update to DiagramEditorContextProvider inside a test was not wrapped in act(...).
packages/open-workflow-diagram-editor build:prod: When testing, code that causes React state updates should be wrapped into act(...):
packages/open-workflow-diagram-editor build:prod: act(() => {
packages/open-workflow-diagram-editor build:prod:   /* fire events that update state */
packages/open-workflow-diagram-editor build:prod: });
```

### How to test:
- `pnpm build:prod` OR open the CI logs from this PR
- No warnings are shown

### Motivation:
Reducing the existing warnings would make CI logs easier to review and help new warnings to be discovered.

### Notes:
This PR also introduces an oxlint configuration making the CI to fail on lint warnings

