### PR TITLE
feat: Add core edit API for modifying the model (update, replace, add and  delete tasks)

### DIFF
--- a/.changeset/core-editing-api.md
+++ b/.changeset/core-editing-api.md
@@ -1,0 +1,5 @@
+---
+"@openworkflowspec/diagram-editor": minor
+---
+
+Add core editing API for updating, replacing, adding and deleting tasks in the model.

--- a/packages/open-workflow-diagram-editor/src/core/index.ts
+++ b/packages/open-workflow-diagram-editor/src/core/index.ts
@@ -15,11 +15,12 @@
  */
 
 export * from "./workflowSdk";
+export * from "./workflowEditing";
 export * from "./validationErrors";
-/* TEMPORARY — remove with the workaround; see the revert checklist in workflowSdk.ts. */
-export * from "./specWorkarounds";
 export * from "./graph";
 export * from "./taskDetails";
 export * from "./taskSubType";
 export * from "./elkjs";
 export * from "./mermaidExport";
+/* TEMPORARY — remove with the workaround; see the revert checklist in workflowSdk.ts. */
+export * from "./specWorkarounds";

--- a/packages/open-workflow-diagram-editor/src/core/workflowEditing.ts
+++ b/packages/open-workflow-diagram-editor/src/core/workflowEditing.ts
@@ -135,14 +135,19 @@ function throwInvalidParent(parentId: string): never {
  *
  * @param taskEntry - Task entry object containing one task name and task value.
  * @returns The task name stored in the entry.
- * @throws Error when the entry has no keys (indicates a malformed task list).
+ * @throws Error when the entry does not have exactly one key.
  */
 function getTaskName(taskEntry: TaskEntry): string {
-  const name = Object.keys(taskEntry)[0];
-  if (name === undefined) {
+  const keys = Object.keys(taskEntry);
+  if (keys.length === 0) {
     throw new Error("Malformed task entry: no task name found");
   }
-  return name;
+  if (keys.length > 1) {
+    throw new Error(
+      `Malformed task entry: expected exactly one key but got ${keys.length} (${keys.join(", ")})`,
+    );
+  }
+  return keys[0]!;
 }
 
 /**
@@ -196,11 +201,11 @@ function forEachSwitchItem(
     }
 
     // Each SwitchItem is a single-key object { [caseName]: SwitchCase }.
-    // Object.values yields exactly one branch per item.
-    for (const branch of Object.values(item as Record<string, unknown>)) {
-      if (branch && typeof branch === "object") {
-        callback(branch as Record<string, unknown>, i, maybeSwitch);
-      }
+    // Only process the first branch to keep itemIndex-to-switch-item mapping deterministic
+    // even if malformed input contains multiple keys.
+    const [branch] = Object.values(item as Record<string, unknown>);
+    if (branch && typeof branch === "object") {
+      callback(branch as Record<string, unknown>, i, maybeSwitch);
     }
   }
 }
@@ -329,9 +334,7 @@ function traversePathTo(
         reachedViaTaskList = true;
         continue;
       }
-    }
-
-    if (current && typeof current === "object" && segment in current) {
+    } else if (current && typeof current === "object" && segment in current) {
       current = (current as Record<string, unknown>)[segment];
       reachedViaTaskList = false;
       continue;
@@ -577,9 +580,10 @@ export function deleteTask(
  *   such as `/do`, `/do/tryBlock/try`, or `/do/loopTask/do`.
  * @param afterTaskId - Optional non-indexed editor task id of the sibling task after which the
  *   new task should be inserted. When omitted the task is appended at the end of the list.
- *   The last path segment is used as the task name to locate the sibling in `parentId`'s list.
+ *   Must be a direct child of `parentId` (i.e. its parent path must equal `parentId`).
  * @returns A copied workflow instance containing the newly added task.
  * @throws Error when `parentId` cannot be resolved to a valid task list in the workflow.
+ * @throws Error when `afterTaskId` is provided but its parent path does not match `parentId`.
  * @throws Error when `afterTaskId` is provided but cannot be found in the resolved task list.
  */
 export function addTask(
@@ -588,6 +592,7 @@ export function addTask(
   parentId: string,
   afterTaskId?: string,
 ): Specification.Workflow {
+  getTaskName(newTask); // validates single-entry contract before mutating
   const workflowDraft = createWorkflowDraft(workflow);
   const container = resolveParentTaskList(workflowDraft, parentId);
 
@@ -598,6 +603,12 @@ export function addTask(
   } else {
     const afterPathSegments = getPathSegments(afterTaskId);
     const afterTaskName = afterPathSegments[afterPathSegments.length - 1]!;
+    const afterParentId = "/" + afterPathSegments.slice(0, -1).join("/");
+
+    if (afterParentId !== parentId) {
+      throw new Error(`afterTaskId "${afterTaskId}" does not belong to parent "${parentId}"`);
+    }
+
     const afterIndex = container.findIndex((entry) => afterTaskName in entry);
 
     if (afterIndex === -1) {

--- a/packages/open-workflow-diagram-editor/src/core/workflowEditing.ts
+++ b/packages/open-workflow-diagram-editor/src/core/workflowEditing.ts
@@ -1,0 +1,613 @@
+/*
+ * Copyright 2021-Present The Open Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Classes, type Specification } from "@openworkflowspec/sdk";
+
+type TaskEntry = Record<string, Specification.Task>;
+
+type TaskMutationTarget = {
+  container: Specification.TaskList;
+  taskEntry: TaskEntry;
+  taskName: string;
+};
+
+/**
+ * Workflow editing helpers in this file expect non-indexed editor task ids.
+ *
+ * These ids use workflow property names and task names instead of numeric task-list indexes.
+ *
+ * Supported examples:
+ * - `/do/step1`
+ * - `/do/tryBlock/try/step1`
+ * - `/do/tryBlock/catch/do/recover`
+ *
+ * Not supported:
+ * - `/do/0/step1`
+ * - `/do/0/tryBlock/try/0/step1`
+ *
+ * Resolution rules:
+ * - object properties are traversed by property name
+ * - task lists such as `do`, `try`, and `catch.do` are traversed by matching task name
+ * - same-name sibling tasks are not allowed at the same level, so name-based lookup is sufficient
+ */
+
+// ---------------------------------------------------------------------------
+// Primitive helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Splits an editor task id into path segments.
+ *
+ * @param taskId - Non-indexed task id used by workflow editing helpers.
+ * @returns The non-empty path segments from the provided task id.
+ */
+function getPathSegments(taskId: string): string[] {
+  return taskId.split("/").filter(Boolean);
+}
+
+/**
+ * Checks whether a value is a workflow task list.
+ *
+ * @param value - Value to test.
+ * @returns `true` when the value is a task list array.
+ */
+function isTaskList(value: unknown): value is Specification.TaskList {
+  return Array.isArray(value);
+}
+
+/**
+ * Finds the task entry object that owns a given task name within a task list.
+ *
+ * A single scan replaces the former `getNamedTask` / `getNamedTaskEntry` pair,
+ * both of which iterated the same list with the same predicate.
+ *
+ * @param taskList - Task list to search.
+ * @param taskName - Task name expected within that list level.
+ * @returns The task entry containing that task name; otherwise `undefined`.
+ */
+function findTaskEntry(taskList: Specification.TaskList, taskName: string): TaskEntry | undefined {
+  return taskList.find((entry) => taskName in entry) as TaskEntry | undefined;
+}
+
+/**
+ * Creates a class-based workflow copy that can be mutated without changing the source workflow.
+ *
+ * @param workflow - Source workflow instance to clone.
+ * @returns A copied workflow instance.
+ */
+function createWorkflowDraft(workflow: Specification.Workflow): Specification.Workflow {
+  return new Classes.Workflow(workflow).normalize();
+}
+
+/**
+ * Creates a SDK task item instance from a named task entry.
+ *
+ * @param taskEntry - Single-entry task object to materialize as a SDK task item.
+ * @returns A SDK task item instance.
+ */
+function createTaskItem(taskEntry: TaskEntry): TaskEntry {
+  return new Classes.TaskItem(taskEntry) as TaskEntry;
+}
+
+/**
+ * Creates a SDK task instance from plain task data.
+ *
+ * @param task - Task data to materialize as a SDK task instance.
+ * @returns A SDK task instance.
+ */
+function createTask(task: Specification.Task): Specification.Task {
+  return new Classes.Task(task) as Specification.Task;
+}
+
+/**
+ * Throws a standardized error when a task id cannot be resolved.
+ *
+ * @param taskId - Task id that could not be resolved.
+ */
+function throwTaskNotFound(taskId: string): never {
+  throw new Error(`Task not found: ${taskId}`);
+}
+
+/**
+ * Throws a standardized error when a parent id cannot be resolved to a valid task list.
+ *
+ * @param parentId - Parent id that could not be resolved.
+ */
+function throwInvalidParent(parentId: string): never {
+  throw new Error(`Invalid parent: ${parentId}`);
+}
+
+/**
+ * Returns the single task name stored in a task entry object.
+ *
+ * @param taskEntry - Task entry object containing one task name and task value.
+ * @returns The task name stored in the entry.
+ * @throws Error when the entry has no keys (indicates a malformed task list).
+ */
+function getTaskName(taskEntry: TaskEntry): string {
+  const name = Object.keys(taskEntry)[0];
+  if (name === undefined) {
+    throw new Error("Malformed task entry: no task name found");
+  }
+  return name;
+}
+
+/**
+ * Reads a same-scope `then` target from a task-like object.
+ *
+ * @param value - Task-like object that may contain a `then` property.
+ * @returns The current `then` value when it is a string; otherwise `undefined`.
+ */
+function getThenValue(value: Record<string, unknown>): string | undefined {
+  // eslint-disable-next-line unicorn/no-thenable -- `then` is an Open Workflow Spec field
+  const thenValue = value["then"];
+  return typeof thenValue === "string" ? thenValue : undefined;
+}
+
+/**
+ * Writes a same-scope `then` target to a task-like object.
+ *
+ * @param value - Task-like object to update.
+ * @param nextTaskName - New `then` target task name.
+ */
+function setThenValue(value: Record<string, unknown>, nextTaskName: string): void {
+  // eslint-disable-next-line unicorn/no-thenable -- `then` is an Open Workflow Spec field
+  value["then"] = nextTaskName;
+}
+
+/**
+ * Iterates over every valid switch branch object inside a task's `switch` array,
+ * calling `callback` with the branch, its parent item index, and the raw switch array.
+ *
+ * Each `SwitchItem` is a single-key object `{ [caseName]: SwitchCase }`.
+ * Only items that are non-null objects are visited; malformed entries are skipped.
+ *
+ * @param task - Task that may contain a `switch` array.
+ * @param callback - Called once per valid branch with `(branch, itemIndex, switchArray)`.
+ */
+function forEachSwitchItem(
+  task: Specification.Task,
+  callback: (branch: Record<string, unknown>, itemIndex: number, switchArray: unknown[]) => void,
+): void {
+  const taskRecord = task as Record<string, unknown>;
+  const maybeSwitch = taskRecord.switch;
+
+  if (!Array.isArray(maybeSwitch)) {
+    return;
+  }
+
+  for (let i = 0; i < maybeSwitch.length; i++) {
+    const item = maybeSwitch[i];
+    if (!item || typeof item !== "object") {
+      continue;
+    }
+
+    // Each SwitchItem is a single-key object { [caseName]: SwitchCase }.
+    // Object.values yields exactly one branch per item.
+    for (const branch of Object.values(item as Record<string, unknown>)) {
+      if (branch && typeof branch === "object") {
+        callback(branch as Record<string, unknown>, i, maybeSwitch);
+      }
+    }
+  }
+}
+
+/**
+ * Removes every switch case inside a task whose `then` value matches a deleted task name.
+ *
+ * ## Why this is necessary
+ *
+ * A `SwitchCase.then` field is **required** and typed as `FlowDirective` — it must either be a
+ * reserved keyword (`continue`, `exit`, `end`) or a valid task name in the same scope.  When a
+ * referenced task is deleted its name ceases to exist in the scope, leaving any pointing `then`
+ * as a dangling reference that would make the workflow invalid.
+ *
+ * Because a switch case exists only to route execution to a target, removing its target makes
+ * the whole case meaningless.  The safest automated recovery is therefore to drop the case
+ * entirely.  Callers that need different semantics (e.g. reassigning the target) must do so
+ * explicitly before calling `deleteTask`.
+ *
+ * The pruning is scope-local: only switch cases that live in sibling tasks of the deleted task
+ * are affected.  Cases nested inside sub-tasks belong to a different scope and are left alone.
+ *
+ * @param task - Sibling task whose inline switch cases may reference the deleted name.
+ * @param deletedTaskName - Name of the task that was just removed from the containing task list.
+ */
+function pruneSwitchCasesReferencingTask(task: Specification.Task, deletedTaskName: string): void {
+  // Collect indices to remove first, then splice in reverse to keep indices stable.
+  const indicesToRemove: number[] = [];
+
+  forEachSwitchItem(task, (branch, itemIndex) => {
+    if (getThenValue(branch) === deletedTaskName) {
+      indicesToRemove.push(itemIndex);
+    }
+  });
+
+  if (indicesToRemove.length === 0) {
+    return;
+  }
+
+  const switchArray = (task as Record<string, unknown>).switch as unknown[];
+  for (const i of indicesToRemove.reverse()) {
+    switchArray.splice(i, 1);
+  }
+}
+
+/**
+ * Updates same-scope `then` references from one task name to another.
+ *
+ * This only rewrites explicit task-name references in the same task scope:
+ * - task-level `then`
+ * - switch branch `then` values in `case` and `default` branches
+ *
+ * @param task - Task whose same-scope references may need rewriting.
+ * @param oldTaskName - Previous task name that may still be referenced.
+ * @param newTaskName - New task name that should replace the previous one.
+ */
+function updateThenReferences(
+  task: Specification.Task,
+  oldTaskName: string,
+  newTaskName: string,
+): void {
+  const taskRecord = task as Record<string, unknown>;
+
+  if (getThenValue(taskRecord) === oldTaskName) {
+    setThenValue(taskRecord, newTaskName);
+  }
+
+  forEachSwitchItem(task, (branch) => {
+    if (getThenValue(branch) === oldTaskName) {
+      setThenValue(branch, newTaskName);
+    }
+  });
+}
+
+/**
+ * Checks whether a value is a task-capable parent — that is, an object that was
+ * reached directly from a task-list entry (making it a task) or is the workflow root.
+ *
+ * This is used to distinguish objects like `ForkTaskConfiguration` (reached via
+ * `fork → config object → branches`) from true task owners such as `DoTask` or `TryTask`
+ * (reached via a task-list lookup).
+ *
+ * @param value - Value to test.
+ * @param reachedViaTaskList - Whether the last traversal step into this value was a task-list lookup.
+ * @param isWorkflowRoot - Whether this value is the workflow root.
+ * @returns `true` when the value can own a sequential child task list.
+ */
+function isTaskCapableParent(
+  value: unknown,
+  reachedViaTaskList: boolean,
+  isWorkflowRoot: boolean,
+): boolean {
+  return isWorkflowRoot || (reachedViaTaskList && typeof value === "object" && value !== null);
+}
+
+/**
+ * Walks `segments` through the workflow object, returning the node reached after the last
+ * segment has been consumed.
+ *
+ * At each step the traversal tries two strategies in order:
+ * 1. **Task-list lookup** — when the current node is an array, find the entry whose key
+ *    matches the segment and step into the task value.  Sets `reachedViaTaskList = true`.
+ * 2. **Object property** — when the segment is a plain property of the current object,
+ *    step into it.  Sets `reachedViaTaskList = false`.
+ *
+ * When neither strategy applies the `onError` callback is invoked (which must throw).
+ *
+ * @param start - Starting node (typically the workflow root).
+ * @param segments - Path segments to walk.
+ * @param onError - Called when a segment cannot be resolved; must throw.
+ * @returns `{ node, reachedViaTaskList }` where `node` is the value after the final step.
+ */
+function traversePathTo(
+  start: unknown,
+  segments: string[],
+  onError: () => never,
+): { node: unknown; reachedViaTaskList: boolean } {
+  let current: unknown = start;
+  let reachedViaTaskList = false;
+
+  for (const segment of segments) {
+    if (isTaskList(current)) {
+      const entry = findTaskEntry(current, segment);
+      if (entry !== undefined) {
+        current = entry[segment];
+        reachedViaTaskList = true;
+        continue;
+      }
+    }
+
+    if (current && typeof current === "object" && segment in current) {
+      current = (current as Record<string, unknown>)[segment];
+      reachedViaTaskList = false;
+      continue;
+    }
+
+    onError();
+  }
+
+  return { node: current, reachedViaTaskList };
+}
+
+/**
+ * Iterates over every task in a task list, calling `callback` with the task value.
+ *
+ * Each entry in a `TaskList` is a single-key object `{ [taskName]: Task }`.
+ * `Object.values(entry)[0]` is always defined for a well-formed list.
+ *
+ * @param container - Task list to iterate.
+ * @param callback - Called once per task entry with the task value.
+ */
+function forEachTaskInList(
+  container: Specification.TaskList,
+  callback: (task: Specification.Task) => void,
+): void {
+  for (const entry of container) {
+    callback(Object.values(entry)[0]! as Specification.Task);
+  }
+}
+
+/**
+ * Resolves a non-indexed editor task id to the task list entry that owns it.
+ *
+ * @param workflow - Workflow containing the target task.
+ * @param taskId - Non-indexed editor task id.
+ * @returns The owning task list, task entry, and task name.
+ * @throws Error when the task id cannot be resolved in the workflow.
+ */
+function resolveTaskMutationTarget(
+  workflow: Specification.Workflow,
+  taskId: string,
+): TaskMutationTarget {
+  const pathSegments = getPathSegments(taskId);
+
+  if (pathSegments.length < 2) {
+    throwTaskNotFound(taskId);
+  }
+
+  // Walk all but the last two segments to reach the node that owns the container array.
+  const { node } = traversePathTo(workflow, pathSegments.slice(0, -2), () =>
+    throwTaskNotFound(taskId),
+  );
+
+  // pathSegments.length >= 2 is guaranteed above, so these two are always defined.
+  const containerName = pathSegments[pathSegments.length - 2]!;
+  const taskName = pathSegments[pathSegments.length - 1]!;
+
+  if (!node || typeof node !== "object") {
+    throwTaskNotFound(taskId);
+  }
+
+  const container = (node as Record<string, unknown>)[containerName];
+
+  if (!isTaskList(container)) {
+    throwTaskNotFound(taskId);
+  }
+
+  const taskEntry = findTaskEntry(container, taskName);
+
+  if (!taskEntry) {
+    throwTaskNotFound(taskId);
+  }
+
+  return { container, taskEntry, taskName };
+}
+
+/**
+ * Resolves a non-indexed editor parent id to the task list it points to.
+ *
+ * The parent id must be a path that ends at a sequential child task-list property
+ * owned by the workflow root or a task node, such as `/do`, `/do/tryBlock/try`,
+ * or `/do/loopTask/do`.
+ *
+ * Intermediate config objects (e.g. `ForkTaskConfiguration` reached via `fork`)
+ * are not considered valid task-capable parents, even when their property resolves
+ * to a `TaskList`.
+ *
+ * @param workflow - Workflow containing the target task list.
+ * @param parentId - Non-indexed editor id pointing to a task list.
+ * @returns The resolved task list.
+ * @throws Error when the parent id cannot be resolved to a task list in the workflow.
+ */
+function resolveParentTaskList(
+  workflow: Specification.Workflow,
+  parentId: string,
+): Specification.TaskList {
+  const pathSegments = getPathSegments(parentId);
+
+  if (pathSegments.length === 0) {
+    throwInvalidParent(parentId);
+  }
+
+  // Walk all but the last segment to reach the task-capable parent node.
+  const { node, reachedViaTaskList } = traversePathTo(workflow, pathSegments.slice(0, -1), () =>
+    throwInvalidParent(parentId),
+  );
+
+  const listName = pathSegments[pathSegments.length - 1]!;
+  const isWorkflowRoot = node === workflow;
+
+  if (!isTaskCapableParent(node, reachedViaTaskList, isWorkflowRoot)) {
+    throwInvalidParent(parentId);
+  }
+
+  if (!node || typeof node !== "object" || !(listName in node)) {
+    throwInvalidParent(parentId);
+  }
+
+  const taskList = (node as Record<string, unknown>)[listName];
+
+  if (!isTaskList(taskList)) {
+    throwInvalidParent(parentId);
+  }
+
+  return taskList;
+}
+
+// ---------------------------------------------------------------------------
+// Exported editing operations
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a copied workflow draft and updates the resolved task in place.
+ *
+ * @param workflow - Source workflow instance to copy and update.
+ * @param taskId - Non-indexed editor task id that identifies the task to update.
+ * @param task - Replacement task to write into the copied workflow.
+ * @returns A copied workflow instance containing the updated task.
+ * @throws Error when the provided task id cannot be resolved in the workflow.
+ */
+export function updateTask(
+  workflow: Specification.Workflow,
+  taskId: string,
+  task: Specification.Task,
+): Specification.Workflow {
+  const workflowDraft = createWorkflowDraft(workflow);
+  const { taskEntry, taskName } = resolveTaskMutationTarget(workflowDraft, taskId);
+
+  taskEntry[taskName] = createTask(task);
+
+  return workflowDraft;
+}
+
+/**
+ * Creates a copied workflow draft and replaces the resolved named task entry.
+ *
+ * This helper is mainly useful when a task needs to be morphed into a different task type
+ * or when the task name itself changes.
+ *
+ * If the replacement task changes the task name, same-scope explicit `then` references
+ * are rewritten in the current task-list scope, including `switch` branch `then` targets.
+ * References in other parent scopes are not searched.
+ *
+ * @param workflow - Source workflow instance to copy and update.
+ * @param taskId - Non-indexed editor task id that identifies the task to replace.
+ * @param newTask - Replacement named task entry to write into the copied workflow.
+ *   This must be a single-entry object such as `{ reviewIssue: { call: "http" } }`.
+ * @returns A copied workflow instance containing the replaced task and any updated same-scope references.
+ * @throws Error when the provided task id cannot be resolved in the workflow.
+ */
+export function replaceTask(
+  workflow: Specification.Workflow,
+  taskId: string,
+  newTask: TaskEntry,
+): Specification.Workflow {
+  const workflowDraft = createWorkflowDraft(workflow);
+  const {
+    container,
+    taskEntry,
+    taskName: oldTaskName,
+  } = resolveTaskMutationTarget(workflowDraft, taskId);
+  const newTaskName = getTaskName(newTask);
+
+  // taskEntry is the live reference inside container — indexOf is O(n) but avoids a second findIndex scan.
+  const targetIndex = container.indexOf(taskEntry);
+  container.splice(targetIndex, 1, createTaskItem(newTask));
+
+  if (newTaskName !== oldTaskName) {
+    forEachTaskInList(container, (siblingTask) =>
+      updateThenReferences(siblingTask, oldTaskName, newTaskName),
+    );
+  }
+
+  return workflowDraft;
+}
+
+/**
+ * Creates a copied workflow draft and deletes the resolved named task entry.
+ *
+ * ## Switch-case pruning
+ *
+ * After the task is removed, every sibling task in the same scope that contains a `switch`
+ * block is scanned.  Any case whose `then` value equals the deleted task name is removed from
+ * that switch array entirely (see {@link pruneSwitchCasesReferencingTask} for rationale).
+ *
+ * This pruning is intentionally scope-local: switch cases in nested sub-tasks are not
+ * touched because they belong to a different task-name scope.
+ *
+ * @param workflow - Source workflow instance to copy and update.
+ * @param taskId - Non-indexed editor task id that identifies the task to delete.
+ * @returns A copied workflow instance without the deleted task and without any same-scope
+ *   switch cases that referenced it.
+ * @throws Error when the provided task id cannot be resolved in the workflow.
+ */
+export function deleteTask(
+  workflow: Specification.Workflow,
+  taskId: string,
+): Specification.Workflow {
+  const workflowDraft = createWorkflowDraft(workflow);
+  const { container, taskEntry, taskName } = resolveTaskMutationTarget(workflowDraft, taskId);
+
+  // taskEntry is the live reference inside container — indexOf avoids a second findIndex scan.
+  const targetIndex = container.indexOf(taskEntry);
+  container.splice(targetIndex, 1);
+
+  // Remove any same-scope switch cases that pointed at the now-deleted task name.
+  forEachTaskInList(container, (siblingTask) =>
+    pruneSwitchCasesReferencingTask(siblingTask, taskName),
+  );
+
+  return workflowDraft;
+}
+
+/**
+ * Creates a copied workflow draft and inserts a new named task entry into the resolved task list.
+ *
+ * The task is inserted after the task identified by `afterTaskId` when provided, or appended
+ * at the end of the list when omitted.
+ *
+ * @param workflow - Source workflow instance to copy and update.
+ * @param newTask - New named task entry to insert.
+ *   This must be a single-entry object such as `{ fetchData: { call: "http" } }`.
+ * @param parentId - Non-indexed editor id pointing to the task list that should receive the task,
+ *   such as `/do`, `/do/tryBlock/try`, or `/do/loopTask/do`.
+ * @param afterTaskId - Optional non-indexed editor task id of the sibling task after which the
+ *   new task should be inserted. When omitted the task is appended at the end of the list.
+ *   The last path segment is used as the task name to locate the sibling in `parentId`'s list.
+ * @returns A copied workflow instance containing the newly added task.
+ * @throws Error when `parentId` cannot be resolved to a valid task list in the workflow.
+ * @throws Error when `afterTaskId` is provided but cannot be found in the resolved task list.
+ */
+export function addTask(
+  workflow: Specification.Workflow,
+  newTask: TaskEntry,
+  parentId: string,
+  afterTaskId?: string,
+): Specification.Workflow {
+  const workflowDraft = createWorkflowDraft(workflow);
+  const container = resolveParentTaskList(workflowDraft, parentId);
+
+  let insertIndex: number;
+
+  if (afterTaskId === undefined) {
+    insertIndex = container.length;
+  } else {
+    const afterPathSegments = getPathSegments(afterTaskId);
+    const afterTaskName = afterPathSegments[afterPathSegments.length - 1]!;
+    const afterIndex = container.findIndex((entry) => afterTaskName in entry);
+
+    if (afterIndex === -1) {
+      throwTaskNotFound(afterTaskId);
+    }
+
+    insertIndex = afterIndex + 1;
+  }
+
+  container.splice(insertIndex, 0, createTaskItem(newTask));
+
+  return workflowDraft;
+}

--- a/packages/open-workflow-diagram-editor/tests/core/workflowEditing.test.ts
+++ b/packages/open-workflow-diagram-editor/tests/core/workflowEditing.test.ts
@@ -1,0 +1,627 @@
+/*
+ * Copyright 2021-Present The Open Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { Classes, type Specification } from "@openworkflowspec/sdk";
+import { addTask, deleteTask, replaceTask, updateTask } from "../../src/core/workflowEditing";
+import { MANAGING_GITHUB_ISSUES_WORKFLOW } from "../fixtures/workflows";
+
+function makeWorkflow(data: object): Specification.Workflow {
+  return new Classes.Workflow(data) as Specification.Workflow;
+}
+
+/** Returns a fresh workflow instance for every test to guarantee isolation. */
+function makeGithubIssuesWorkflow(): Specification.Workflow {
+  return makeWorkflow(MANAGING_GITHUB_ISSUES_WORKFLOW);
+}
+
+// ---------------------------------------------------------------------------
+// updateTask
+// ---------------------------------------------------------------------------
+
+describe("updateTask", () => {
+  let workflow: Specification.Workflow;
+
+  beforeEach(() => {
+    workflow = makeGithubIssuesWorkflow();
+  });
+
+  it("returns a new workflow instance (immutability)", () => {
+    const result = updateTask(workflow, "/do/initialize", { set: { issue: "updated" } });
+
+    expect(result).not.toBe(workflow);
+  });
+
+  it("updates a root-level set task", () => {
+    const updated: Specification.Task = { set: { issue: "patched" } };
+
+    const result = updateTask(workflow, "/do/initialize", updated);
+
+    expect(result.do?.[0]).toEqual({ initialize: updated });
+  });
+
+  it("does not mutate the original workflow when updating a root task", () => {
+    const original = JSON.stringify(workflow);
+
+    updateTask(workflow, "/do/initialize", { set: { issue: "changed" } });
+
+    expect(JSON.stringify(workflow)).toBe(original);
+  });
+
+  it("updates a root-level switch task (evaluateDevWorkOutcome)", () => {
+    const updated: Specification.Task = { set: { result: "noop" } };
+
+    const result = updateTask(workflow, "/do/evaluateDevWorkOutcome", updated);
+
+    expect(result.do?.[2]).toEqual({ evaluateDevWorkOutcome: updated });
+    // Original unchanged
+    expect((workflow.do![2] as Record<string, unknown>)["evaluateDevWorkOutcome"]).toMatchObject({
+      switch: expect.any(Array),
+    });
+  });
+
+  it("updates a nested task inside awaitForDevWork.do (assign)", () => {
+    const updated: Specification.Task = { set: { issue: { assignedTo: "OpsTeam" } } };
+
+    const result = updateTask(workflow, "/do/awaitForDevWork/do/assign", updated);
+
+    const awaitForDevWork = result.do?.[1] as { awaitForDevWork: { do: unknown[] } };
+    expect(awaitForDevWork.awaitForDevWork.do[0]).toEqual({ assign: updated });
+    // Original nested task unchanged
+    const original = workflow.do?.[1] as { awaitForDevWork: { do: Record<string, unknown>[] } };
+    expect(original.awaitForDevWork.do[0]).not.toEqual({ assign: updated });
+  });
+
+  it("updates a deeply nested task inside evaluateReview.do (closeIssue.do/closeIssueOnGithub)", () => {
+    const updated: Specification.Task = {
+      call: "http",
+      with: { endpoint: "https://api.github.com/new", method: "delete" },
+    };
+
+    const result = updateTask(
+      workflow,
+      "/do/evaluateReview/do/closeIssue/do/closeIssueOnGithub",
+      updated,
+    );
+
+    const evaluateReview = result.do?.[6] as {
+      evaluateReview: { do: { closeIssue: { do: unknown[] } }[] };
+    };
+    const closeIssueDo = evaluateReview.evaluateReview.do[4]!;
+    expect((closeIssueDo as { closeIssue: { do: unknown[] } }).closeIssue.do[1]).toEqual({
+      closeIssueOnGithub: updated,
+    });
+  });
+
+  it.each([
+    ["/do/missing", "Task not found: /do/missing"],
+    ["/do/awaitForDevWork/do/missing", "Task not found: /do/awaitForDevWork/do/missing"],
+    [
+      "/do/evaluateReview/do/closeIssue/do/missing",
+      "Task not found: /do/evaluateReview/do/closeIssue/do/missing",
+    ],
+  ])("throws '%s' when the task id cannot be resolved", (taskId, expectedMessage) => {
+    expect(() => updateTask(workflow, taskId, { set: { x: 1 } })).toThrow(expectedMessage);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// replaceTask
+// ---------------------------------------------------------------------------
+
+describe("replaceTask", () => {
+  let workflow: Specification.Workflow;
+
+  beforeEach(() => {
+    workflow = makeGithubIssuesWorkflow();
+  });
+
+  it("returns a new workflow instance (immutability)", () => {
+    const result = replaceTask(workflow, "/do/initialize", {
+      initializeRenamed: { set: { issue: "patched" } },
+    });
+
+    expect(result).not.toBe(workflow);
+  });
+
+  it("replaces a root-level task with a same-named entry (task body swap)", () => {
+    const result = replaceTask(workflow, "/do/initialize", {
+      initialize: { call: "http", with: { method: "get" } },
+    });
+
+    expect(result.do?.[0]).toEqual({ initialize: { call: "http", with: { method: "get" } } });
+    expect(result.do).toHaveLength(MANAGING_GITHUB_ISSUES_WORKFLOW.do.length);
+  });
+
+  it("does not mutate the original workflow when replacing a root task", () => {
+    const original = JSON.stringify(workflow);
+
+    replaceTask(workflow, "/do/initialize", { initialize: { set: { issue: "changed" } } });
+
+    expect(JSON.stringify(workflow)).toBe(original);
+  });
+
+  it("replaces a root task and renames it (evaluateDevWorkOutcome → decideNextStep)", () => {
+    const result = replaceTask(workflow, "/do/evaluateDevWorkOutcome", {
+      decideNextStep: { set: { decision: "pending" } },
+    });
+
+    expect(result.do?.[2]).toEqual({ decideNextStep: { set: { decision: "pending" } } });
+  });
+
+  it("updates same-scope then references when a root task is renamed", () => {
+    // awaitForDevWork.then === "evaluateDevWorkOutcome" — renaming it should update that reference
+    const result = replaceTask(workflow, "/do/evaluateDevWorkOutcome", {
+      decideNextStep: { set: { decision: "pending" } },
+    });
+
+    // eslint-disable-next-line unicorn/no-thenable -- `then` is an Open Workflow Spec field
+    const awaitForDevWork = result.do?.[1] as { awaitForDevWork: { then: string } };
+    // eslint-disable-next-line unicorn/no-thenable -- `then` is an Open Workflow Spec field
+    expect(awaitForDevWork.awaitForDevWork.then).toBe("decideNextStep");
+  });
+
+  it("updates switch branch then references when a root task referenced by switch branches is renamed", () => {
+    // evaluateDevWorkOutcome switch has branches pointing to reviewIssue and awaitDetailsFromQA
+    const result = replaceTask(workflow, "/do/reviewIssue", {
+      reviewIssueRenamed: { set: { status: "reviewing" } },
+    });
+
+    const evaluateDevWorkOutcome = result.do?.[2] as {
+      evaluateDevWorkOutcome: { switch: Record<string, Record<string, string>>[] };
+    };
+    const reviewBranch = evaluateDevWorkOutcome.evaluateDevWorkOutcome.switch[0]!["review"]!;
+    expect(reviewBranch["when"]).toBe('$context.issue.action == "review"');
+    expect(reviewBranch["then"]).toBe("reviewIssueRenamed");
+  });
+
+  it("does not update then references in nested scopes when renaming a root task", () => {
+    // Nested tasks named 'notify' exist in multiple scopes — renaming root 'raiseUnsupportedActionError'
+    // must NOT affect 'then' values inside nested do-blocks (different scope).
+    const originalInnerThen = JSON.stringify(
+      (workflow.do![6] as { evaluateReview: { do: unknown[] } }).evaluateReview.do,
+    );
+
+    replaceTask(workflow, "/do/raiseUnsupportedActionError", {
+      raiseUnsupportedActionErrorRenamed: {
+        raise: { error: { type: "x", status: 400, title: "x" } },
+      },
+    });
+
+    const afterInnerThen = JSON.stringify(
+      (workflow.do![6] as { evaluateReview: { do: unknown[] } }).evaluateReview.do,
+    );
+    expect(afterInnerThen).toBe(originalInnerThen);
+  });
+
+  it("replaces a nested task inside awaitForDevWork.do (notify → emitEvent)", () => {
+    const result = replaceTask(workflow, "/do/awaitForDevWork/do/notify", {
+      emitEvent: { emit: { event: { with: { type: "custom.v1" } } } },
+    });
+
+    const awaitForDevWork = result.do?.[1] as { awaitForDevWork: { do: unknown[] } };
+    expect(awaitForDevWork.awaitForDevWork.do[1]).toEqual({
+      emitEvent: { emit: { event: { with: { type: "custom.v1" } } } },
+    });
+  });
+
+  it("replaces a deeply nested task inside evaluateReview.do.closeIssue.do", () => {
+    const result = replaceTask(workflow, "/do/evaluateReview/do/closeIssue/do/closeIssueOnGithub", {
+      patchIssueOnGithub: {
+        call: "http",
+        with: { endpoint: "https://example.com", method: "put" },
+      },
+    });
+
+    const evaluateReview = result.do?.[6] as {
+      evaluateReview: { do: { closeIssue: { do: unknown[] } }[] };
+    };
+    expect(
+      (evaluateReview.evaluateReview.do[4] as { closeIssue: { do: unknown[] } }).closeIssue.do[1],
+    ).toEqual({
+      patchIssueOnGithub: {
+        call: "http",
+        with: { endpoint: "https://example.com", method: "put" },
+      },
+    });
+  });
+
+  it.each([
+    ["/do/missing", "Task not found: /do/missing"],
+    ["/do/awaitForDevWork/do/missing", "Task not found: /do/awaitForDevWork/do/missing"],
+    [
+      "/do/evaluateReview/do/closeIssue/do/missing",
+      "Task not found: /do/evaluateReview/do/closeIssue/do/missing",
+    ],
+  ])("throws '%s' when the task id cannot be resolved", (taskId, expectedMessage) => {
+    expect(() => replaceTask(workflow, taskId, { replacement: { set: { x: 1 } } })).toThrow(
+      expectedMessage,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteTask
+// ---------------------------------------------------------------------------
+
+describe("deleteTask", () => {
+  let workflow: Specification.Workflow;
+
+  beforeEach(() => {
+    workflow = makeGithubIssuesWorkflow();
+  });
+
+  it("returns a new workflow instance (immutability)", () => {
+    const result = deleteTask(workflow, "/do/initialize");
+
+    expect(result).not.toBe(workflow);
+  });
+
+  it("deletes a root-level task (initialize)", () => {
+    const result = deleteTask(workflow, "/do/initialize");
+
+    expect(result.do).toHaveLength(MANAGING_GITHUB_ISSUES_WORKFLOW.do.length - 1);
+    expect(result.do?.[0]).not.toHaveProperty("initialize");
+  });
+
+  it("does not mutate the original workflow when deleting a root task", () => {
+    const original = JSON.stringify(workflow);
+
+    deleteTask(workflow, "/do/initialize");
+
+    expect(JSON.stringify(workflow)).toBe(original);
+  });
+
+  it("deletes a root-level switch task (validateReview)", () => {
+    const before = workflow.do?.length ?? 0;
+    const result = deleteTask(workflow, "/do/validateReview");
+
+    expect(result.do).toHaveLength(before - 1);
+    const names = result.do?.map((entry) => Object.keys(entry)[0]);
+    expect(names).not.toContain("validateReview");
+  });
+
+  it("deletes a root-level raise task (raiseUnsupportedActionError)", () => {
+    const result = deleteTask(workflow, "/do/raiseUnsupportedActionError");
+
+    const names = result.do?.map((entry) => Object.keys(entry)[0]);
+    expect(names).not.toContain("raiseUnsupportedActionError");
+  });
+
+  it("deletes a nested task inside awaitForDevWork.do (notify)", () => {
+    const result = deleteTask(workflow, "/do/awaitForDevWork/do/notify");
+
+    const awaitForDevWork = result.do?.[1] as { awaitForDevWork: { do: unknown[] } };
+    expect(awaitForDevWork.awaitForDevWork.do).toHaveLength(2); // assign + await remain
+    const nestedNames = awaitForDevWork.awaitForDevWork.do.map((e) => Object.keys(e as object)[0]);
+    expect(nestedNames).not.toContain("notify");
+  });
+
+  it("does not affect siblings when deleting a nested task", () => {
+    const result = deleteTask(workflow, "/do/awaitForDevWork/do/assign");
+
+    const awaitForDevWork = result.do?.[1] as { awaitForDevWork: { do: unknown[] } };
+    const nestedNames = awaitForDevWork.awaitForDevWork.do.map((e) => Object.keys(e as object)[0]);
+    expect(nestedNames).toEqual(["notify", "await"]);
+  });
+
+  it("deletes a deeply nested task inside evaluateReview.do.closeIssue.do (setIssueInfo)", () => {
+    const result = deleteTask(workflow, "/do/evaluateReview/do/closeIssue/do/setIssueInfo");
+
+    const evaluateReview = result.do?.[6] as {
+      evaluateReview: { do: { closeIssue: { do: unknown[] } }[] };
+    };
+    const closeIssueDo = (evaluateReview.evaluateReview.do[4] as { closeIssue: { do: unknown[] } })
+      .closeIssue.do;
+    const names = closeIssueDo.map((e) => Object.keys(e as object)[0]);
+    expect(names).not.toContain("setIssueInfo");
+    expect(closeIssueDo).toHaveLength(3); // initialize + closeIssueOnGithub + notify
+  });
+
+  // ── Switch-case pruning ────────────────────────────────────────────────────
+
+  it("removes switch cases that reference the deleted root task (reviewIssue → review case removed)", () => {
+    // evaluateDevWorkOutcome.switch has a 'review' case with then: "reviewIssue"
+    const result = deleteTask(workflow, "/do/reviewIssue");
+
+    const evaluateDevWorkOutcome = result.do?.find((e) => "evaluateDevWorkOutcome" in e) as {
+      evaluateDevWorkOutcome: {
+        switch: { review?: unknown; requestDetails?: unknown; default?: unknown }[];
+      };
+    };
+    const switchCases = evaluateDevWorkOutcome.evaluateDevWorkOutcome.switch;
+    const caseNames = switchCases.map((item) => Object.keys(item)[0]);
+    expect(caseNames).not.toContain("review");
+    // The other two cases must be preserved
+    expect(caseNames).toContain("requestDetails");
+    expect(caseNames).toContain("default");
+  });
+
+  it("removes switch cases that reference the deleted root task (awaitDetailsFromQA → requestDetails case removed)", () => {
+    // evaluateDevWorkOutcome.switch has a 'requestDetails' case with then: "awaitDetailsFromQA"
+    const result = deleteTask(workflow, "/do/awaitDetailsFromQA");
+
+    const evaluateDevWorkOutcome = result.do?.find((e) => "evaluateDevWorkOutcome" in e) as {
+      evaluateDevWorkOutcome: { switch: unknown[] };
+    };
+    const caseNames = evaluateDevWorkOutcome.evaluateDevWorkOutcome.switch.map(
+      (item) => Object.keys(item as object)[0],
+    );
+    expect(caseNames).not.toContain("requestDetails");
+    // 'review' and 'default' are unaffected
+    expect(caseNames).toContain("review");
+    expect(caseNames).toContain("default");
+  });
+
+  it("removes switch cases that reference the deleted root task (raiseUnsupportedActionError → default case removed from evaluateDevWorkOutcome)", () => {
+    const result = deleteTask(workflow, "/do/raiseUnsupportedActionError");
+
+    const evaluateDevWorkOutcome = result.do?.find((e) => "evaluateDevWorkOutcome" in e) as {
+      evaluateDevWorkOutcome: { switch: unknown[] };
+    };
+    const caseNames = evaluateDevWorkOutcome.evaluateDevWorkOutcome.switch.map(
+      (item) => Object.keys(item as object)[0],
+    );
+    expect(caseNames).not.toContain("default");
+  });
+
+  it("removes switch cases that reference the deleted nested task inside evaluateReview.do (closeIssue)", () => {
+    // evaluateReview.do contains an 'evaluate' switch with a 'closeIssue' case pointing to 'closeIssue'
+    const result = deleteTask(workflow, "/do/evaluateReview/do/closeIssue");
+
+    const evaluateReview = result.do?.find((e) => "evaluateReview" in e) as {
+      evaluateReview: { do: unknown[] };
+    };
+    const evaluateSwitchEntry = evaluateReview.evaluateReview.do.find(
+      (e) => "evaluate" in (e as object),
+    ) as { evaluate: { switch: unknown[] } };
+    const caseNames = evaluateSwitchEntry.evaluate.switch.map(
+      (item) => Object.keys(item as object)[0],
+    );
+    expect(caseNames).not.toContain("closeIssue");
+    // 'default' case still present (points to "exit", not the deleted task)
+    expect(caseNames).toContain("default");
+  });
+
+  it("does not prune switch cases in nested scopes when a root-level task is deleted", () => {
+    // Deleting a root task must not affect switch cases in a deeper scope.
+    // evaluateReview.do.evaluate.switch has a 'closeIssue' case — deleting the root 'reviewIssue'
+    // must leave the inner 'closeIssue' case intact.
+    const result = deleteTask(workflow, "/do/reviewIssue");
+
+    const evaluateReview = result.do?.find((e) => "evaluateReview" in e) as {
+      evaluateReview: { do: unknown[] };
+    };
+    const evaluateSwitchEntry = evaluateReview.evaluateReview.do.find(
+      (e) => "evaluate" in (e as object),
+    ) as { evaluate: { switch: unknown[] } };
+    const innerCaseNames = evaluateSwitchEntry.evaluate.switch.map(
+      (item) => Object.keys(item as object)[0],
+    );
+    expect(innerCaseNames).toContain("closeIssue");
+    expect(innerCaseNames).toContain("default");
+  });
+
+  it("does not prune switch cases that point to reserved flow directives (end, exit, continue)", () => {
+    // raiseUnsupportedActionError.then === "end" (reserved) — deleting 'raiseAssignedDevCannotBeReviewer'
+    // must leave the 'reviewerIsAssignedDev' case in validateReview.switch intact because its then
+    // points to the task being deleted, but we want to verify reserved-directive cases are untouched
+    // by an unrelated deletion. Deleting 'initialize' must not affect validateReview.switch at all.
+    const result = deleteTask(workflow, "/do/initialize");
+
+    const validateReview = result.do?.find((e) => "validateReview" in e) as {
+      validateReview: { switch: unknown[] };
+    };
+    const caseNames = validateReview.validateReview.switch.map(
+      (item) => Object.keys(item as object)[0],
+    );
+    // Both cases still present — neither points to 'initialize'
+    expect(caseNames).toContain("reviewerIsNotAssignedDev");
+    expect(caseNames).toContain("reviewerIsAssignedDev");
+  });
+
+  it.each([
+    ["/do/missing", "Task not found: /do/missing"],
+    ["/do/awaitForDevWork/do/missing", "Task not found: /do/awaitForDevWork/do/missing"],
+    [
+      "/do/evaluateReview/do/closeIssue/do/missing",
+      "Task not found: /do/evaluateReview/do/closeIssue/do/missing",
+    ],
+  ])("throws '%s' when the task id cannot be resolved", (taskId, expectedMessage) => {
+    expect(() => deleteTask(workflow, taskId)).toThrow(expectedMessage);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addTask
+// ---------------------------------------------------------------------------
+
+describe("addTask", () => {
+  let workflow: Specification.Workflow;
+
+  beforeEach(() => {
+    workflow = makeGithubIssuesWorkflow();
+  });
+
+  it("returns a new workflow instance (immutability)", () => {
+    const result = addTask(workflow, { newTask: { set: { x: 1 } } }, "/do");
+
+    expect(result).not.toBe(workflow);
+  });
+
+  it("appends a new task at the end of the root task list when afterTaskId is omitted", () => {
+    const before = workflow.do?.length ?? 0;
+
+    const result = addTask(workflow, { finalize: { set: { done: true } } }, "/do");
+
+    expect(result.do).toHaveLength(before + 1);
+    expect(result.do?.[before]).toEqual({ finalize: { set: { done: true } } });
+  });
+
+  it("does not mutate the original workflow when appending to root", () => {
+    const original = JSON.stringify(workflow);
+
+    addTask(workflow, { finalize: { set: { done: true } } }, "/do");
+
+    expect(JSON.stringify(workflow)).toBe(original);
+  });
+
+  it("inserts a new task after initialize at the root level", () => {
+    const result = addTask(
+      workflow,
+      { validate: { set: { valid: true } } },
+      "/do",
+      "/do/initialize",
+    );
+
+    expect(result.do?.[1]).toEqual({ validate: { set: { valid: true } } });
+    // initialize stays at index 0
+    expect(result.do?.[0]).toHaveProperty("initialize");
+    // awaitForDevWork shifts to index 2
+    expect(result.do?.[2]).toHaveProperty("awaitForDevWork");
+  });
+
+  it("inserts a new task after the last root task (raiseAssignedDevCannotBeReviewer)", () => {
+    const lastIndex = (workflow.do?.length ?? 1) - 1;
+
+    const result = addTask(
+      workflow,
+      { cleanup: { set: { done: true } } },
+      "/do",
+      "/do/raiseAssignedDevCannotBeReviewer",
+    );
+
+    expect(result.do?.[lastIndex + 1]).toEqual({ cleanup: { set: { done: true } } });
+  });
+
+  it("appends a new task to a nested task list (awaitForDevWork.do)", () => {
+    const result = addTask(workflow, { log: { set: { logged: true } } }, "/do/awaitForDevWork/do");
+
+    const awaitForDevWork = result.do?.[1] as { awaitForDevWork: { do: unknown[] } };
+    expect(awaitForDevWork.awaitForDevWork.do).toHaveLength(4); // assign + notify + await + log
+    expect(awaitForDevWork.awaitForDevWork.do[3]).toEqual({ log: { set: { logged: true } } });
+  });
+
+  it("inserts a task after 'assign' inside awaitForDevWork.do", () => {
+    const result = addTask(
+      workflow,
+      { preNotify: { set: { ready: true } } },
+      "/do/awaitForDevWork/do",
+      "/do/awaitForDevWork/do/assign",
+    );
+
+    const awaitForDevWork = result.do?.[1] as { awaitForDevWork: { do: unknown[] } };
+    expect(awaitForDevWork.awaitForDevWork.do[1]).toEqual({ preNotify: { set: { ready: true } } });
+    expect(awaitForDevWork.awaitForDevWork.do[0]).toHaveProperty("assign");
+    expect(awaitForDevWork.awaitForDevWork.do[2]).toHaveProperty("notify");
+  });
+
+  it("appends a task to a deeply nested task list (evaluateReview.do.closeIssue.do)", () => {
+    const result = addTask(
+      workflow,
+      { audit: { set: { audited: true } } },
+      "/do/evaluateReview/do/closeIssue/do",
+    );
+
+    const evaluateReview = result.do?.[6] as {
+      evaluateReview: { do: { closeIssue: { do: unknown[] } }[] };
+    };
+    const closeIssueDo = (evaluateReview.evaluateReview.do[4] as { closeIssue: { do: unknown[] } })
+      .closeIssue.do;
+    expect(closeIssueDo).toHaveLength(5); // initialize + closeIssueOnGithub + setIssueInfo + notify + audit
+    expect(closeIssueDo[4]).toEqual({ audit: { set: { audited: true } } });
+  });
+
+  it("throws when parentId points to a fork/branches list (not a task-capable parent)", () => {
+    const wf = makeWorkflow({
+      document: { dsl: "1.0.3", name: "test", version: "1.0.0", namespace: "default" },
+      do: [
+        {
+          parallelWork: {
+            fork: {
+              branches: [
+                { branchA: { set: { variable: "a" } } },
+                { branchB: { set: { variable: "b" } } },
+              ],
+            },
+          },
+        },
+      ],
+    });
+
+    expect(() =>
+      addTask(wf, { branchC: { set: { variable: "c" } } }, "/do/parallelWork/fork/branches"),
+    ).toThrow("Invalid parent: /do/parallelWork/fork/branches");
+  });
+
+  it("inserts a task after 'initialize' inside evaluateReview.do.closeIssue.do", () => {
+    const result = addTask(
+      workflow,
+      { checkPermissions: { set: { allowed: true } } },
+      "/do/evaluateReview/do/closeIssue/do",
+      "/do/evaluateReview/do/closeIssue/do/initialize",
+    );
+
+    const evaluateReview = result.do?.[6] as {
+      evaluateReview: { do: { closeIssue: { do: unknown[] } }[] };
+    };
+    const closeIssueDo = (evaluateReview.evaluateReview.do[4] as { closeIssue: { do: unknown[] } })
+      .closeIssue.do;
+    expect(closeIssueDo[0]).toHaveProperty("initialize");
+    expect(closeIssueDo[1]).toEqual({ checkPermissions: { set: { allowed: true } } });
+    expect(closeIssueDo[2]).toHaveProperty("closeIssueOnGithub");
+  });
+
+  it.each([
+    // parentId resolves to a task (not a list) — initialize has no child do-list
+    ["/do/initialize", undefined, "Invalid parent: /do/initialize"],
+    // parentId points to a non-existent intermediate segment
+    ["/do/missing/do", undefined, "Invalid parent: /do/missing/do"],
+    // parentId is an empty string (no segments)
+    ["", undefined, "Invalid parent: "],
+  ])(
+    "throws '%s' when parentId cannot be resolved to a valid task list",
+    (parentId, _afterTaskId, expectedMessage) => {
+      expect(() => addTask(workflow, { newTask: { set: { x: 1 } } }, parentId)).toThrow(
+        expectedMessage,
+      );
+    },
+  );
+
+  it.each([
+    // afterTaskId not in root list
+    ["/do", "/do/missing", "Task not found: /do/missing"],
+    // afterTaskId not in nested list
+    [
+      "/do/awaitForDevWork/do",
+      "/do/awaitForDevWork/do/missing",
+      "Task not found: /do/awaitForDevWork/do/missing",
+    ],
+    // afterTaskId not in deeply nested list
+    [
+      "/do/evaluateReview/do/closeIssue/do",
+      "/do/evaluateReview/do/closeIssue/do/missing",
+      "Task not found: /do/evaluateReview/do/closeIssue/do/missing",
+    ],
+  ])(
+    "throws when afterTaskId '%s' cannot be found in the task list",
+    (parentId, afterTaskId, expectedMessage) => {
+      expect(() =>
+        addTask(workflow, { newTask: { set: { x: 1 } } }, parentId, afterTaskId),
+      ).toThrow(expectedMessage);
+    },
+  );
+});

--- a/packages/open-workflow-diagram-editor/tests/core/workflowEditing.test.ts
+++ b/packages/open-workflow-diagram-editor/tests/core/workflowEditing.test.ts
@@ -23,6 +23,19 @@ function makeWorkflow(data: object): Specification.Workflow {
   return new Classes.Workflow(data) as Specification.Workflow;
 }
 
+function getTaskByName(workflow: Specification.Workflow, taskName: string): Specification.Task {
+  const taskEntry = workflow.do?.find((entry) => taskName in entry) as
+    | Record<string, Specification.Task>
+    | undefined;
+  expect(taskEntry).toBeDefined();
+  return taskEntry![taskName]!;
+}
+
+function getSwitchCaseNames(task: Specification.Task): string[] {
+  const switchItems = (task as { switch?: Record<string, unknown>[] }).switch ?? [];
+  return switchItems.map((item) => Object.keys(item)[0]!);
+}
+
 /** Returns a fresh workflow instance for every test to guarantee isolation. */
 function makeGithubIssuesWorkflow(): Specification.Workflow {
   return makeWorkflow(MANAGING_GITHUB_ISSUES_WORKFLOW);
@@ -251,6 +264,15 @@ describe("replaceTask", () => {
       expectedMessage,
     );
   });
+
+  it("throws when newTask has more than one key", () => {
+    expect(() =>
+      replaceTask(workflow, "/do/initialize", {
+        taskA: { set: { x: 1 } },
+        taskB: { set: { x: 2 } },
+      } as unknown as Parameters<typeof replaceTask>[2]),
+    ).toThrow("Malformed task entry: expected exactly one key but got 2 (taskA, taskB)");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -333,50 +355,88 @@ describe("deleteTask", () => {
 
   // ── Switch-case pruning ────────────────────────────────────────────────────
 
-  it("removes switch cases that reference the deleted root task (reviewIssue → review case removed)", () => {
-    // evaluateDevWorkOutcome.switch has a 'review' case with then: "reviewIssue"
-    const result = deleteTask(workflow, "/do/reviewIssue");
+  it.each([
+    {
+      deletedTaskId: "/do/reviewIssue",
+      deletedCaseName: "review",
+      expectedRemainingCaseNames: ["requestDetails", "default"],
+    },
+    {
+      deletedTaskId: "/do/awaitDetailsFromQA",
+      deletedCaseName: "requestDetails",
+      expectedRemainingCaseNames: ["review", "default"],
+    },
+    {
+      deletedTaskId: "/do/raiseUnsupportedActionError",
+      deletedCaseName: "default",
+      expectedRemainingCaseNames: ["review", "requestDetails"],
+    },
+  ])(
+    "removes only the expected switch branch when deleting $deletedTaskId",
+    ({ deletedTaskId, deletedCaseName, expectedRemainingCaseNames }) => {
+      const result = deleteTask(workflow, deletedTaskId);
+      const evaluateDevWorkOutcome = getTaskByName(result, "evaluateDevWorkOutcome");
+      const caseNames = getSwitchCaseNames(evaluateDevWorkOutcome);
 
-    const evaluateDevWorkOutcome = result.do?.find((e) => "evaluateDevWorkOutcome" in e) as {
-      evaluateDevWorkOutcome: {
-        switch: { review?: unknown; requestDetails?: unknown; default?: unknown }[];
-      };
-    };
-    const switchCases = evaluateDevWorkOutcome.evaluateDevWorkOutcome.switch;
-    const caseNames = switchCases.map((item) => Object.keys(item)[0]);
-    expect(caseNames).not.toContain("review");
-    // The other two cases must be preserved
-    expect(caseNames).toContain("requestDetails");
-    expect(caseNames).toContain("default");
+      expect(caseNames).not.toContain(deletedCaseName);
+      expect(caseNames).toEqual(expectedRemainingCaseNames);
+    },
+  );
+
+  it("prunes only the first matching malformed multi-key switch item when deleting its referenced task", () => {
+    const malformedWorkflow = makeWorkflow({
+      document: {
+        dsl: "0.9",
+        namespace: "test",
+        name: "malformed-switch-item",
+        version: "0.1.0",
+      },
+      do: [
+        { removeMe: { set: { value: "remove" } } },
+        { keepMe: { set: { value: "keep" } } },
+        {
+          decide: {
+            switch: [
+              // oxlint-disable-next-line unicorn/no-thenable
+              {
+                malformedPrimary: { when: "$primary", then: "removeMe" }, // oxlint-disable-line unicorn/no-thenable
+                malformedSecondary: { when: "$secondary", then: "removeMe" }, // oxlint-disable-line unicorn/no-thenable
+              },
+              { keepCase: { when: "$keep", then: "keepMe" } }, // oxlint-disable-line unicorn/no-thenable
+            ],
+          },
+        },
+      ],
+    });
+
+    const result = deleteTask(malformedWorkflow, "/do/removeMe");
+    const decide = getTaskByName(result, "decide");
+
+    expect(getSwitchCaseNames(decide)).toEqual(["keepCase"]);
   });
 
-  it("removes switch cases that reference the deleted root task (awaitDetailsFromQA → requestDetails case removed)", () => {
-    // evaluateDevWorkOutcome.switch has a 'requestDetails' case with then: "awaitDetailsFromQA"
-    const result = deleteTask(workflow, "/do/awaitDetailsFromQA");
+  it.each([
+    {
+      deletedTaskId: "/do/reviewIssue",
+      expectedRemainingCaseNames: ["requestDetails", "default"],
+    },
+    {
+      deletedTaskId: "/do/awaitDetailsFromQA",
+      expectedRemainingCaseNames: ["review", "default"],
+    },
+    {
+      deletedTaskId: "/do/raiseUnsupportedActionError",
+      expectedRemainingCaseNames: ["review", "requestDetails"],
+    },
+  ])(
+    "removes only the targeted switch branch when deleting first, middle, or last referenced task: $deletedTaskId",
+    ({ deletedTaskId, expectedRemainingCaseNames }) => {
+      const result = deleteTask(workflow, deletedTaskId);
+      const evaluateDevWorkOutcome = getTaskByName(result, "evaluateDevWorkOutcome");
 
-    const evaluateDevWorkOutcome = result.do?.find((e) => "evaluateDevWorkOutcome" in e) as {
-      evaluateDevWorkOutcome: { switch: unknown[] };
-    };
-    const caseNames = evaluateDevWorkOutcome.evaluateDevWorkOutcome.switch.map(
-      (item) => Object.keys(item as object)[0],
-    );
-    expect(caseNames).not.toContain("requestDetails");
-    // 'review' and 'default' are unaffected
-    expect(caseNames).toContain("review");
-    expect(caseNames).toContain("default");
-  });
-
-  it("removes switch cases that reference the deleted root task (raiseUnsupportedActionError → default case removed from evaluateDevWorkOutcome)", () => {
-    const result = deleteTask(workflow, "/do/raiseUnsupportedActionError");
-
-    const evaluateDevWorkOutcome = result.do?.find((e) => "evaluateDevWorkOutcome" in e) as {
-      evaluateDevWorkOutcome: { switch: unknown[] };
-    };
-    const caseNames = evaluateDevWorkOutcome.evaluateDevWorkOutcome.switch.map(
-      (item) => Object.keys(item as object)[0],
-    );
-    expect(caseNames).not.toContain("default");
-  });
+      expect(getSwitchCaseNames(evaluateDevWorkOutcome)).toEqual(expectedRemainingCaseNames);
+    },
+  );
 
   it("removes switch cases that reference the deleted nested task inside evaluateReview.do (closeIssue)", () => {
     // evaluateReview.do contains an 'evaluate' switch with a 'closeIssue' case pointing to 'closeIssue'
@@ -416,10 +476,9 @@ describe("deleteTask", () => {
   });
 
   it("does not prune switch cases that point to reserved flow directives (end, exit, continue)", () => {
-    // raiseUnsupportedActionError.then === "end" (reserved) — deleting 'raiseAssignedDevCannotBeReviewer'
-    // must leave the 'reviewerIsAssignedDev' case in validateReview.switch intact because its then
-    // points to the task being deleted, but we want to verify reserved-directive cases are untouched
-    // by an unrelated deletion. Deleting 'initialize' must not affect validateReview.switch at all.
+    // Deleting 'initialize' is unrelated to validateReview.switch — neither of its cases points to
+    // 'initialize'. The 'reviewerIsAssignedDev' case has then === "end" (a reserved flow directive),
+    // which is never a candidate for pruning regardless. Both cases must survive the deletion unchanged.
     const result = deleteTask(workflow, "/do/initialize");
 
     const validateReview = result.do?.find((e) => "validateReview" in e) as {
@@ -624,4 +683,44 @@ describe("addTask", () => {
       ).toThrow(expectedMessage);
     },
   );
+
+  it.each([
+    // afterTaskId belongs to the root scope but parentId is a nested list
+    [
+      "/do/awaitForDevWork/do",
+      "/do/initialize",
+      `afterTaskId "/do/initialize" does not belong to parent "/do/awaitForDevWork/do"`,
+    ],
+    // afterTaskId belongs to a sibling nested scope
+    [
+      "/do/awaitForDevWork/do",
+      "/do/evaluateReview/do/closeIssue/do/initialize",
+      `afterTaskId "/do/evaluateReview/do/closeIssue/do/initialize" does not belong to parent "/do/awaitForDevWork/do"`,
+    ],
+    // afterTaskId belongs to a deeper nested scope but parentId is the root list
+    [
+      "/do",
+      "/do/awaitForDevWork/do/assign",
+      `afterTaskId "/do/awaitForDevWork/do/assign" does not belong to parent "/do"`,
+    ],
+  ])(
+    "throws when afterTaskId '%s' is from a different scope than parentId",
+    (parentId, afterTaskId, expectedMessage) => {
+      expect(() =>
+        addTask(workflow, { newTask: { set: { x: 1 } } }, parentId, afterTaskId),
+      ).toThrow(expectedMessage);
+    },
+  );
+  it("throws when newTask has more than one key", () => {
+    expect(() =>
+      addTask(
+        workflow,
+        {
+          taskA: { set: { x: 1 } },
+          taskB: { set: { x: 2 } },
+        } as unknown as Parameters<typeof addTask>[1],
+        "/do",
+      ),
+    ).toThrow("Malformed task entry: expected exactly one key but got 2 (taskA, taskB)");
+  });
 });

--- a/packages/open-workflow-diagram-editor/tests/fixtures/workflows.ts
+++ b/packages/open-workflow-diagram-editor/tests/fixtures/workflows.ts
@@ -151,6 +151,351 @@ export const EMPTY_WORKFLOW_JSON = JSON.stringify({
   do: [],
 });
 
+/**
+ * "Managing GitHub Issues" workflow — sourced from storybook use-cases.
+ *
+ * This is a complex, real-world workflow that exercises:
+ * - nested `do` tasks at multiple levels
+ * - `switch` tasks with named branches
+ * - `listen`, `emit`, `set`, `raise`, and `call` tasks
+ * - cross-task `then` references
+ */
+export const MANAGING_GITHUB_ISSUES_WORKFLOW = {
+  document: {
+    dsl: "1.0.3",
+    namespace: "default",
+    name: "manage-github-issues",
+    version: "0.1.0",
+  },
+  schedule: {
+    on: {
+      one: {
+        with: {
+          type: "com.github.events.issues.opened.v1",
+          data: '${ .data.author.team == "QA" }',
+        },
+      },
+    },
+  },
+  do: [
+    {
+      initialize: {
+        set: { issue: "${ $workflow.input[0].data }" },
+        export: { as: ".issue" },
+      },
+    },
+    {
+      awaitForDevWork: {
+        do: [
+          {
+            assign: {
+              set: { issue: { assignedTo: "DevTeam", status: "inProgress" } },
+            },
+          },
+          {
+            notify: {
+              emit: {
+                event: {
+                  with: {
+                    source: "https://open-workflow-specification.org",
+                    type: "com.github.events.issues.assignedToDevTeam.v1",
+                    data: { issue: "${ .issue }" },
+                  },
+                },
+              },
+            },
+          },
+          {
+            await: {
+              listen: {
+                to: {
+                  one: {
+                    with: { type: "com.github.events.issues.devWorkCompleted.v1" },
+                  },
+                },
+              },
+              export: {
+                as: "$context + { issue: ($context.issue + { action: .data.nextAction, dev: .data.dev }) }",
+              },
+            },
+          },
+        ],
+        // eslint-disable-next-line unicorn/no-thenable -- `then` is an Open Workflow Spec field
+        then: "evaluateDevWorkOutcome",
+      },
+    },
+    {
+      evaluateDevWorkOutcome: {
+        switch: [
+          {
+            review: {
+              when: '$context.issue.action == "review"',
+              // eslint-disable-next-line unicorn/no-thenable -- `then` is an Open Workflow Spec field
+              then: "reviewIssue",
+            },
+          },
+          {
+            requestDetails: {
+              when: '$context.issue.action == "requestDetails"',
+              // eslint-disable-next-line unicorn/no-thenable -- `then` is an Open Workflow Spec field
+              then: "awaitDetailsFromQA",
+            },
+          },
+          {
+            default: {
+              // eslint-disable-next-line unicorn/no-thenable -- `then` is an Open Workflow Spec field
+              then: "raiseUnsupportedActionError",
+            },
+          },
+        ],
+      },
+    },
+    {
+      awaitDetailsFromQA: {
+        do: [
+          {
+            assign: {
+              set: {
+                issue: {
+                  assignedTo: "QA",
+                  status: "awaitingDetails",
+                  assignTo: "${ $context.issue.author }",
+                },
+              },
+            },
+          },
+          {
+            notify: {
+              emit: {
+                event: {
+                  with: {
+                    source: "https://open-workflow-specification.org",
+                    type: "com.github.events.issues.assignedToQATeam.v1",
+                    data: { issue: "${ $context.issue }" },
+                  },
+                },
+              },
+            },
+          },
+          {
+            await: {
+              listen: {
+                to: {
+                  one: {
+                    with: { type: "com.github.events.issues.detailsProvided.v1" },
+                  },
+                },
+              },
+              export: {
+                as: "$context + { issue: ($context.issue + { action: .data.nextAction }) }",
+              },
+            },
+          },
+        ],
+        // eslint-disable-next-line unicorn/no-thenable -- `then` is an Open Workflow Spec field
+        then: "awaitForDevWork",
+      },
+    },
+    {
+      reviewIssue: {
+        do: [
+          {
+            assign: {
+              set: { issue: { assignedTo: "DevTeam", status: "reviewing" } },
+            },
+          },
+          {
+            notify: {
+              emit: {
+                event: {
+                  with: {
+                    source: "https://open-workflow-specification.org",
+                    type: "com.github.events.issues.pendingReview.v1",
+                    data: {
+                      issue: "${ $context.issue }",
+                      review: { exclude: "${ $context.issue.dev }" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          {
+            await: {
+              listen: {
+                to: {
+                  one: {
+                    with: { type: "com.github.events.issues.reviewed.v1" },
+                  },
+                },
+              },
+              export: {
+                as: "$context + { issue: ($context.issue + { reviewer: .data.reviewer }) }",
+              },
+            },
+          },
+        ],
+      },
+    },
+    {
+      validateReview: {
+        switch: [
+          {
+            reviewerIsNotAssignedDev: {
+              when: "$context.issue.reviewer != $context.issue.dev",
+              // eslint-disable-next-line unicorn/no-thenable -- `then` is an Open Workflow Spec field
+              then: "evaluateReview",
+            },
+          },
+          {
+            reviewerIsAssignedDev: {
+              // eslint-disable-next-line unicorn/no-thenable -- `then` is an Open Workflow Spec field
+              then: "raiseAssignedDevCannotBeReviewer",
+            },
+          },
+        ],
+      },
+    },
+    {
+      evaluateReview: {
+        do: [
+          {
+            assign: {
+              set: { issue: { assignedTo: "QA", status: "evaluating" } },
+            },
+          },
+          {
+            notify: {
+              emit: {
+                event: {
+                  with: {
+                    source: "https://open-workflow-specification.org",
+                    type: "com.github.events.issues.evaluateReview.v1",
+                    data: {
+                      issue: "${ $context.issue }",
+                      assignTo: "${ $context.issue.author }",
+                    },
+                  },
+                },
+              },
+            },
+          },
+          {
+            await: {
+              listen: {
+                to: {
+                  one: {
+                    with: { type: "com.github.events.issues.evaluated.v1" },
+                  },
+                },
+              },
+              export: {
+                as: "$context + { issue: ($context.issue + { action: .data.nextAction }) }",
+              },
+            },
+          },
+          {
+            evaluate: {
+              switch: [
+                {
+                  closeIssue: {
+                    when: '$context.issue.action == "close"',
+                    // eslint-disable-next-line unicorn/no-thenable -- `then` is an Open Workflow Spec field
+                    then: "closeIssue",
+                  },
+                },
+                {
+                  default: {
+                    // eslint-disable-next-line unicorn/no-thenable -- `then` is an Open Workflow Spec field
+                    then: "exit",
+                  },
+                },
+              ],
+            },
+          },
+          {
+            closeIssue: {
+              do: [
+                {
+                  initialize: {
+                    set: {
+                      organization: "${ $context.issue.repository.organization }",
+                      repository: "${ $context.issue.repository.name }",
+                      issueNumber: "${ $context.issue.number }",
+                    },
+                  },
+                },
+                {
+                  closeIssueOnGithub: {
+                    call: "http",
+                    with: {
+                      endpoint:
+                        "https://api.github.com/repos/{organization}/{repository}/issues/{issueNumber}",
+                      method: "patch",
+                      body: { state: "closed" },
+                    },
+                  },
+                },
+                {
+                  setIssueInfo: {
+                    set: { issue: { status: "closed" } },
+                  },
+                },
+                {
+                  notify: {
+                    emit: {
+                      event: {
+                        with: {
+                          source: "https://open-workflow-specification.org",
+                          type: "com.github.events.issues.closed.v1",
+                          data: { issue: "${ $context.issue }" },
+                        },
+                      },
+                    },
+                  },
+                },
+              ],
+              // eslint-disable-next-line unicorn/no-thenable -- `then` is an Open Workflow Spec field
+              then: "end",
+            },
+          },
+        ],
+        // eslint-disable-next-line unicorn/no-thenable -- `then` is an Open Workflow Spec field
+        then: "awaitForDevWork",
+      },
+    },
+    {
+      raiseUnsupportedActionError: {
+        raise: {
+          error: {
+            type: "https://open-workflow-specification.org/spec/1.0.0/errors/runtime",
+            status: 400,
+            title: "Unsupported Action",
+            detail: "The specified action is not supported in this context",
+          },
+        },
+        // eslint-disable-next-line unicorn/no-thenable -- `then` is an Open Workflow Spec field
+        then: "end",
+      },
+    },
+    {
+      raiseAssignedDevCannotBeReviewer: {
+        raise: {
+          error: {
+            type: "https://open-workflow-specification.org/spec/1.0.0/errors/runtime",
+            status: 400,
+            title: "Invalid Reviewer",
+            detail:
+              "The developer that has performed the work associated with the issue cannot be the reviewer of its own work",
+          },
+        },
+        // eslint-disable-next-line unicorn/no-thenable -- `then` is an Open Workflow Spec field
+        then: "end",
+      },
+    },
+  ],
+};
+
 export const PARSEABLE_INVALID_WORKFLOW_YAML = `
   document:
     dsl: '1.0.3'


### PR DESCRIPTION
Closes https://github.com/open-workflow-specification/editor/issues/325

## Summary
This PR introduces a core API to modify the model by updating, replacing, adding and deleting tasks and then returning a draft model (model to be).

## Changes
* Added `core/workflowEditing.ts` file to host the API to handle changes in the model.
* Added `updateTask` function to update a task with new property values.
* Added `replaceTask` function to handle cases when a task name changes affecting the id, and for cases where the task type changes. It also updates the references to the new task in other tasks at the same level (`taskList`).
* Added `addTask` function to add new tasks to a specific path (`parentId`).
* Added `deleteTask` function to remove tasks and remove references to the deleted task.
