### PR TITLE
fix #343 - feat: enable netlify preview CI for feature branches

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -30,16 +30,16 @@
     set -e -o pipefail
 
     if [ -n "${REVIEW_ID:-}" ]; then
+      # For PR previews, fetch GitHub's synthetic merge commit.
       FETCH_REF="refs/pull/${REVIEW_ID}/merge"
-      BASE_REV="FETCH_HEAD^1"
     else
-      FETCH_REF="main"
-      BASE_REV="FETCH_HEAD"
+      # For branch builds, fetch the branch being deployed.
+      FETCH_REF="$BRANCH"
     fi
 
     git fetch --no-tags --depth=2 origin "$FETCH_REF"
-    BASE_REF="$(git rev-parse "$BASE_REV")"
-    echo "FETCH_REF=$FETCH_REF BASE_REV=$BASE_REV BASE_REF=$BASE_REF"
+    BASE_REF="$(git rev-parse FETCH_HEAD^1)"
+    echo "FETCH_REF=$FETCH_REF BASE_REF=$BASE_REF"
 
     npm i -g "pnpm@$PNPM_VERSION"
     ! pnpm -F "...[$BASE_REF]" -rc exec 'echo "$PNPM_PACKAGE_NAME"' | grep -Fqx "$PREVIEW_PACKAGE_NAME"

--- a/netlify.toml
+++ b/netlify.toml
@@ -37,7 +37,8 @@
       FETCH_REF="$BRANCH"
     fi
 
-    git fetch --no-tags --depth=2 origin "$FETCH_REF"
+    # Always deploy if fetch fails.
+    git fetch --no-tags --depth=2 origin "$FETCH_REF" || exit 1
     BASE_REF="$(git rev-parse FETCH_HEAD^1)"
     echo "FETCH_REF=$FETCH_REF BASE_REF=$BASE_REF"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -28,7 +28,18 @@
   publish = "packages/open-workflow-diagram-editor/dist-storybook"
   ignore = """
     set -e -o pipefail
-    git fetch --no-tags --depth=1 origin main:refs/remotes/origin/main
+
+    if [ -n "${REVIEW_ID:-}" ]; then
+      FETCH_REF="refs/pull/${REVIEW_ID}/merge"
+      BASE_REV="FETCH_HEAD^1"
+    else
+      FETCH_REF="main"
+      BASE_REV="FETCH_HEAD"
+    fi
+
+    git fetch --no-tags --depth=2 origin "$FETCH_REF"
+    BASE_REF="$(git rev-parse "$BASE_REV")"
+
     npm i -g "pnpm@$PNPM_VERSION"
-    ! pnpm -F '...[origin/main]' -rc exec 'echo "$PNPM_PACKAGE_NAME"' | grep -Fqx "$PREVIEW_PACKAGE_NAME"
+    ! pnpm -F "...[$BASE_REF]" -rc exec 'echo "$PNPM_PACKAGE_NAME"' | grep -Fqx "$PREVIEW_PACKAGE_NAME"
   """

--- a/netlify.toml
+++ b/netlify.toml
@@ -39,6 +39,7 @@
 
     git fetch --no-tags --depth=2 origin "$FETCH_REF"
     BASE_REF="$(git rev-parse "$BASE_REV")"
+    echo "FETCH_REF=$FETCH_REF BASE_REV=$BASE_REV BASE_REF=$BASE_REF"
 
     npm i -g "pnpm@$PNPM_VERSION"
     ! pnpm -F "...[$BASE_REF]" -rc exec 'echo "$PNPM_PACKAGE_NAME"' | grep -Fqx "$PREVIEW_PACKAGE_NAME"


### PR DESCRIPTION
Closes https://github.com/open-workflow-specification/editor/issues/343

### Action required
@ricardozanini 
- Open: https://app.netlify.com/projects/[project-name]/configuration/deploys#branches-and-deploy-contexts
- Go to **Branches and deploy contexts** → **Configure**
- Set **Branch deploys** to **All**

### Description

Currently PRs against feature branches don't have the Netlify previews.
We need to update the configuration to enable them.

### Motivation

Reviewing UI and UX changes is much easier when a live preview is available directly from the PR.

### Proposed Implementation

- Update `netlify.toml`
- Update Deploy configuration from Netlify panel

### Tests using my fork
- PR against `main`: https://github.com/fantonangeli/open-workflow-specification-editor/pull/18
- PR against `feature/node-editing`: https://github.com/fantonangeli/open-workflow-specification-editor/pull/20
- Automatic deploy from `main`:  https://app.netlify.com/projects/serverlessworkflow-editor/deploys/6a8ecb762f480700088c7cf6
- Automatic deploy from `feature/node-editing`: https://app.netlify.com/projects/serverlessworkflow-editor/deploys/6a8ecd1da7ec8c00083b165a  