### PR TITLE
fix #329 - feat: Create the language-service package

### DIFF
--- a/.changeset/create-language-service.md
+++ b/.changeset/create-language-service.md
@@ -1,0 +1,5 @@
+---
+"@openworkflowspec/language-service": minor
+---
+
+Create the language service package foundation

--- a/.syncpackrc.json
+++ b/.syncpackrc.json
@@ -8,6 +8,13 @@
   },
   "versionGroups": [
     {
+      "label": "Only language-service may depend on Volar. See the Architecture section in packages/language-service/README.md.",
+      "dependencies": ["@volar/**", "volar-service-*"],
+      "packages": ["!@openworkflowspec/language-service"],
+      "dependencyTypes": ["prod", "dev", "peer"],
+      "isBanned": true
+    },
+    {
       "label": "Ignore root package version",
       "packages": ["open-workflow-editor"],
       "dependencyTypes": ["local"],

--- a/packages/language-service/.oxfmtrc.json
+++ b/packages/language-service/.oxfmtrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../.oxfmtrc.json"]
+}

--- a/packages/language-service/.oxlintrc.json
+++ b/packages/language-service/.oxlintrc.json
@@ -1,0 +1,22 @@
+{
+  "extends": ["../../.oxlintrc.json"],
+  "overrides": [
+    {
+      "files": ["src/**/*.{ts,tsx}"],
+      "excludeFiles": ["src/volar/**"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              {
+                "group": ["@volar/*", "volar-service-*"],
+                "message": "Volar dependencies may only be imported from src/volar. See the Architecture section in README.md."
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/language-service/README.md
+++ b/packages/language-service/README.md
@@ -1,0 +1,51 @@
+<!--
+   Copyright 2021-Present The Open Workflow Specification Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+# @openworkflowspec/language-service
+
+Language service foundation for the Open Workflow Specification, built on [Volar](https://volarjs.dev/).
+
+The package provides the common infrastructure for Open Workflow language features.
+
+## Architecture
+
+Volar-specific code is isolated under `src/volar/`. Imports from `@volar/*` outside this directory are prevented by Oxlint.
+
+```text
+src/
+├── index.ts
+└── volar/
+    └── index.ts
+```
+
+## Development
+
+```bash
+# Run unit tests
+pnpm test
+
+# Linting
+pnpm lint
+
+# Build package (development)
+pnpm run build:dev
+
+# Build package (production - includes linting and tests)
+pnpm run build:prod
+
+# Build Storybook static site
+pnpm run build:storybook
+```

--- a/packages/language-service/README.md
+++ b/packages/language-service/README.md
@@ -45,7 +45,4 @@ pnpm run build:dev
 
 # Build package (production - includes linting and tests)
 pnpm run build:prod
-
-# Build Storybook static site
-pnpm run build:storybook
 ```

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@openworkflowspec/language-service",
+  "version": "1.1.0",
+  "private": true,
+  "description": "Open Workflow language service foundation",
+  "keywords": [],
+  "homepage": "https://github.com/open-workflow-specification/editor",
+  "bugs": {
+    "url": "https://github.com/open-workflow-specification/editor/issues"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-workflow-specification/editor.git"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "clean": "rimraf ./dist",
+    "build:dev": "pnpm clean && tsc -p tsconfig.json && vite build",
+    "build:prod": "pnpm lint && pnpm run build:dev && pnpm test",
+    "lint": "oxlint --config .oxlintrc.json src/ tests/",
+    "format": "oxfmt --config .oxfmtrc.json",
+    "format:check": "oxfmt --config .oxfmtrc.json --check",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@volar/language-service": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
+    "rimraf": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/language-service/src/index.ts
+++ b/packages/language-service/src/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2021-Present The Open Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from "./volar/index";

--- a/packages/language-service/src/volar/index.ts
+++ b/packages/language-service/src/volar/index.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021-Present The Open Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { createLanguageService } from "@volar/language-service";
+
+export type {
+  LanguageService,
+  LanguageServiceEnvironment,
+  LanguageServicePlugin,
+  ProjectContext,
+} from "@volar/language-service";

--- a/packages/language-service/tests/languageService.test.ts
+++ b/packages/language-service/tests/languageService.test.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021-Present The Open Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createLanguageService } from "../src/index";
+
+describe("createLanguageService", () => {
+  it("re-exports createLanguageService from @volar/language-service", () => {
+    expect(typeof createLanguageService).toBe("function");
+  });
+});

--- a/packages/language-service/tsconfig.json
+++ b/packages/language-service/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": false,
+    "emitDeclarationOnly": true,
+    "noEmitOnError": true,
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/language-service/vite.config.ts
+++ b/packages/language-service/vite.config.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021-Present The Open Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  resolve: {
+    tsconfigPaths: true,
+  },
+  build: {
+    emptyOutDir: false,
+    sourcemap: true,
+    lib: {
+      entry: "src/index.ts",
+      fileName: (format) => (format === "es" ? "index.js" : `index.${format}.js`),
+      formats: ["es"],
+    },
+  },
+});

--- a/packages/language-service/vite.config.ts
+++ b/packages/language-service/vite.config.ts
@@ -28,5 +28,8 @@ export default defineConfig({
       fileName: (format) => (format === "es" ? "index.js" : `index.${format}.js`),
       formats: ["es"],
     },
+    rollupOptions: {
+      external: [/^@volar\//],
+    },
   },
 });

--- a/packages/language-service/vitest.config.ts
+++ b/packages/language-service/vitest.config.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021-Present The Open Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    tsconfigPaths: true,
+  },
+  test: {
+    globals: true,
+    environment: "node",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ catalogs:
     '@vitest/ui':
       specifier: ^4.1.11
       version: 4.1.11
+    '@volar/language-service':
+      specifier: ^2.4.28
+      version: 2.4.28
     '@xyflow/react':
       specifier: ^12.11.3
       version: 12.11.3
@@ -252,6 +255,34 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 19.2.8(react@19.2.8)
+      rimraf:
+        specifier: 'catalog:'
+        version: 6.1.3
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vite:
+        specifier: 'catalog:'
+        version: 8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.11(@types/node@26.2.0)(@vitest/browser-playwright@4.1.11)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+
+  packages/language-service:
+    dependencies:
+      '@volar/language-service':
+        specifier: 'catalog:'
+        version: 2.4.28
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 26.2.0
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.64.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.77.0
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -2692,6 +2723,15 @@ packages:
   '@vitest/utils@4.1.11':
     resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
 
+  '@volar/language-core@2.4.28':
+    resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
+
+  '@volar/language-service@2.4.28':
+    resolution: {integrity: sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw==}
+
+  '@volar/source-map@2.4.28':
+    resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
+
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
@@ -3938,6 +3978,22 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  vscode-jsonrpc@9.0.2:
+    resolution: {integrity: sha512-SbQSV9yRemARxeXw6LU5sS6Zq0e9/DgCCX5yelH263ZQWukbTk8EF8fjTrr1dziasf4GwlJbvTwFnTrnQFWZXQ==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-languageserver-protocol@3.18.3:
+    resolution: {integrity: sha512-DF49+WeV5py4zO5hhobp60jjsDSK0lAqA0OuKBLBvp423HPWQcCbhZz3JgyfIewsEz2f8U+X75xNIFHdiXZm2w==}
+
+  vscode-languageserver-textdocument@1.0.14:
+    resolution: {integrity: sha512-EQyqJMi552E4ZTf46izQ4Fj6XquqxCySR3J5ZSD1SisMf6RfpeOWHxGBE8Gr6V0/3GHIGdAzDn8F8+1nTGCnoQ==}
+
+  vscode-languageserver-types@3.18.3:
+    resolution: {integrity: sha512-XIlzJ7Qp/jzSI1ds7/FwPAWrPeTZA7pAtlW4hdJ1J6xXWJL6dR9QYnDhJOdLzdKhUQ5Mm6mvUMw+3DcOQQasPw==}
+
+  vscode-uri@3.2.0:
+    resolution: {integrity: sha512-m2gXo3bn0G1kT9InzMf07fTbqMbGtyckj3bH5ktLO+1Ssv+yiATZ4dhwaQv9UZWxJh6E9IFGnQyjgWVDWVBDrg==}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -6081,6 +6137,19 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@volar/language-core@2.4.28':
+    dependencies:
+      '@volar/source-map': 2.4.28
+
+  '@volar/language-service@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      vscode-languageserver-protocol: 3.18.3
+      vscode-languageserver-textdocument: 1.0.14
+      vscode-uri: 3.2.0
+
+  '@volar/source-map@2.4.28': {}
+
   '@webcontainer/env@1.1.1': {}
 
   '@xyflow/react@12.11.3(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
@@ -7257,6 +7326,19 @@ snapshots:
       jsdom: 30.0.1
     transitivePeerDependencies:
       - msw
+
+  vscode-jsonrpc@9.0.2: {}
+
+  vscode-languageserver-protocol@3.18.3:
+    dependencies:
+      vscode-jsonrpc: 9.0.2
+      vscode-languageserver-types: 3.18.3
+
+  vscode-languageserver-textdocument@1.0.14: {}
+
+  vscode-languageserver-types@3.18.3: {}
+
+  vscode-uri@3.2.0: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - packages/*
   - examples/*
 catalog:
+  "@volar/language-service": ^2.4.28
   "@changesets/changelog-github": ^1.0.0
   "@changesets/cli": ^3.0.1
   "@chromatic-com/storybook": ^5.3.0


### PR DESCRIPTION
Closes https://github.com/open-workflow-specification/editor/issues/329

### Description

Language service spike: https://github.com/open-workflow-specification/editor/issues/209

Create `packages/language-service `(`@openworkflowspec/language-service`), based on `@volar/language-service`, to provide the common foundation for the JSON and YAML language services.

### Motivation

Provide the common, editor-agnostic package foundation required to implement Open Workflow-specific authoring assistance.

## How to test:
- `pnpm --filter @openworkflowspec/language-service test`