### PR TITLE
feat: Add foundation for edit form

### DIFF
--- a/.changeset/add-edit-form.md
+++ b/.changeset/add-edit-form.md
@@ -1,0 +1,5 @@
+---
+"@openworkflowspec/diagram-editor": patch
+---
+
+Add foundation for edit form

--- a/packages/open-workflow-diagram-editor/src/components/ui/field.tsx
+++ b/packages/open-workflow-diagram-editor/src/components/ui/field.tsx
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2021-Present The Open Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMemo } from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+
+function FieldSet({ className, ...props }: React.ComponentProps<"fieldset">) {
+  return (
+    <fieldset
+      data-slot="field-set"
+      className={cn(
+        "dec:flex dec:flex-col dec:gap-6",
+        "dec:has-[>[data-slot=checkbox-group]]:gap-3 dec:has-[>[data-slot=radio-group]]:gap-3",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function FieldLegend({
+  className,
+  variant = "legend",
+  ...props
+}: React.ComponentProps<"legend"> & { variant?: "legend" | "label" }) {
+  return (
+    <legend
+      data-slot="field-legend"
+      data-variant={variant}
+      className={cn(
+        "dec:mb-3 dec:font-medium",
+        "dec:data-[variant=legend]:text-base",
+        "dec:data-[variant=label]:text-sm",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function FieldGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-group"
+      className={cn(
+        "dec:group/field-group dec:@container/field-group dec:flex dec:w-full dec:flex-col dec:gap-7 dec:data-[slot=checkbox-group]:gap-3 dec:[&>[data-slot=field-group]]:gap-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+const fieldVariants = cva(
+  "dec:group/field dec:flex dec:w-full dec:gap-3 dec:data-[invalid=true]:text-destructive",
+  {
+    variants: {
+      orientation: {
+        vertical: ["dec:flex-col [&>*]:w-full [&>.sr-only]:w-auto"],
+        horizontal: [
+          "dec:flex-row dec:items-center",
+          "dec:[&>[data-slot=field-label]]:dec:flex-auto",
+          "dec:has-[>[data-slot=field-content]]:dec:items-start dec:has-[>[data-slot=field-content]]:dec:[&>[role=checkbox],[role=radio]]:dec:mt-px",
+        ],
+        responsive: [
+          "dec:flex-col @md/field-group:dec:flex-row @md/field-group:dec:items-center [@>*]:dec:w-full @md/field-group:[@>*]:dec:w-auto [@>.sr-only]:dec:w-auto",
+          "@md/field-group:[&>[data-slot=field-label]]:dec:flex-auto",
+          "@md/field-group:dec:has-[>[data-slot=field-content]]:dec:items-start @md/field-group:dec:has-[>[data-slot=field-content]]:dec:[&>[role=checkbox],[role=radio]]:dec:mt-px",
+        ],
+      },
+    },
+    defaultVariants: {
+      orientation: "vertical",
+    },
+  },
+);
+
+function Field({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof fieldVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="field"
+      data-orientation={orientation}
+      className={cn(fieldVariants({ orientation }), className)}
+      {...props}
+    />
+  );
+}
+
+function FieldContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-content"
+      className={cn(
+        "dec:group/field-content dec:flex dec:flex-1 dec:flex-col dec:gap-1.5 dec:leading-snug",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function FieldLabel({ className, ...props }: React.ComponentProps<typeof Label>) {
+  return (
+    <Label
+      data-slot="field-label"
+      className={cn(
+        "dec:group/field-label dec:peer/field-label dec:flex dec:w-fit dec:gap-2 dec:leading-snug dec:group-data-[disabled=true]/field:opacity-50",
+        "dec:has-[>[data-slot=field]]:w-full dec:has-[>[data-slot=field]]:flex-col dec:has-[>[data-slot=field]]:rounded-md dec:has-[>[data-slot=field]]:border dec:[&>*]:data-[slot=field]:p-4",
+        "dec:has-data-[state=checked]:border-primary dec:has-data-[state=checked]:bg-primary/5 dec:dark:has-data-[state=checked]:bg-primary/10",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function FieldTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-label"
+      className={cn(
+        "dec:flex dec:w-fit dec:items-center dec:gap-2 dec:text-sm dec:leading-snug dec:font-medium dec:group-data-[disabled=true]/field:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function FieldDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="field-description"
+      className={cn(
+        "dec:text-sm dec:leading-normal dec:font-normal dec:text-muted-foreground dec:group-has-[[data-orientation=horizontal]]/field:text-balance",
+        "dec:last:mt-0 dec:nth-last-2:-mt-1 dec:[[data-variant=legend]+&]:-mt-1.5",
+        "dec:[&>a]:underline dec:[&>a]:underline-offset-4 dec:[&>a:hover]:text-primary",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function FieldSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & {
+  children?: React.ReactNode;
+}) {
+  return (
+    <div
+      data-slot="field-separator"
+      data-content={!!children}
+      className={cn(
+        "dec:relative dec:-my-2 dec:h-5 dec:text-sm dec:group-data-[variant=outline]/field-group:-mb-2",
+        className,
+      )}
+      {...props}
+    >
+      <Separator className="dec:absolute dec:inset-0 dec:top-1/2" />
+      {children && (
+        <span
+          className="dec:relative dec:mx-auto dec:block dec:w-fit dec:bg-background dec:px-2 dec:text-muted-foreground"
+          data-slot="field-separator-content"
+        >
+          {children}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function FieldError({
+  className,
+  children,
+  errors,
+  ...props
+}: React.ComponentProps<"div"> & {
+  errors?: Array<{ message?: string } | undefined>;
+}) {
+  const content = useMemo(() => {
+    if (children) {
+      return children;
+    }
+
+    if (!errors?.length) {
+      return null;
+    }
+
+    const uniqueErrors = [...new Map(errors.map((error) => [error?.message, error])).values()];
+
+    if (uniqueErrors?.length == 1) {
+      return uniqueErrors[0]?.message;
+    }
+
+    return (
+      <ul className="dec:ml-4 dec:flex dec:list-disc dec:flex-col dec:gap-1">
+        {uniqueErrors.map((error, index) => error?.message && <li key={index}>{error.message}</li>)}
+      </ul>
+    );
+  }, [children, errors]);
+
+  if (!content) {
+    return null;
+  }
+
+  return (
+    <div
+      role="alert"
+      data-slot="field-error"
+      className={cn("dec:text-sm dec:font-normal dec:text-destructive", className)}
+      {...props}
+    >
+      {content}
+    </div>
+  );
+}
+
+export {
+  Field,
+  FieldLabel,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLegend,
+  FieldSeparator,
+  FieldSet,
+  FieldContent,
+  FieldTitle,
+};

--- a/packages/open-workflow-diagram-editor/src/components/ui/label.tsx
+++ b/packages/open-workflow-diagram-editor/src/components/ui/label.tsx
@@ -14,18 +14,22 @@
  * limitations under the License.
  */
 
-import type { DetailField } from "@/core/taskDetails";
-import { PropertyField } from "./Fields";
+import * as React from "react";
+import { Label as LabelPrimitive } from "radix-ui";
 
-/**
- * Static presentation of a task's flattened properties.
- */
-export function ReadOnlyProperties({ fields }: { fields: DetailField[] }) {
+import { cn } from "@/lib/utils";
+
+function Label({ className, ...props }: React.ComponentProps<typeof LabelPrimitive.Root>) {
   return (
-    <dl>
-      {fields.map((field) => (
-        <PropertyField key={field.label} field={field} />
-      ))}
-    </dl>
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "dec:flex dec:items-center dec:gap-2 dec:text-sm dec:leading-none dec:font-medium dec:select-none dec:group-data-[disabled=true]:pointer-events-none dec:group-data-[disabled=true]:opacity-50 dec:peer-disabled:cursor-not-allowed dec:peer-disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
   );
 }
+
+export { Label };

--- a/packages/open-workflow-diagram-editor/src/core/taskDetails.ts
+++ b/packages/open-workflow-diagram-editor/src/core/taskDetails.ts
@@ -22,44 +22,26 @@ const TASK_BASE_KEYS = new Set(["if", "input", "output", "export", "timeout", "t
 /* Number of object levels to expand into dot-notation rows */
 const MAX_DEPTH = 4;
 
-/* Flattened task row - kind: how the view should render it */
+/* Flattened task row"
+    - kind: how the view should render it 
+    - label: the dot-joined display label(`with.method`)
+    - segments: the real key path and source of truth 
+*/
+type DetailFieldBase = { label: string; segments: string[] };
+
 export type DetailField =
-  | { path: string; kind: "scalar"; value: string | number | boolean }
-  | { path: string; kind: "enum"; value: string; options: string[] }
-  | { path: string; kind: "runtime-expression"; value: string }
-  | { path: string; kind: "duration"; value: string }
-  | { path: string; kind: "long-string"; value: string }
-  | { path: string; kind: "array"; count: number }
-  | { path: string; kind: "object" };
+  | (DetailFieldBase & { kind: "scalar"; value: string | number | boolean })
+  /* TODO: Temporary until rendering arrays and objects */
+  | (DetailFieldBase & { kind: "array"; count: number })
+  | (DetailFieldBase & { kind: "object" });
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-//  This is temporary function  until we dynamically build the form with field types
-function isLongStringField(path: string): boolean {
-  return path === "run.shell.command" || path === "run.script.code";
-}
-
-function isRuntimeExpressionField(path: string): boolean {
-  return path === "if";
-}
-
-function isDurationField(path: string): boolean {
-  return path === "timeout" || path === "timeout.after";
-}
-
-const ENUM_FIELDS: Record<string, string[]> = {
-  "with.output": ["raw", "content", "response"],
-};
-
-function getEnumOptions(path: string): string[] | undefined {
-  return ENUM_FIELDS[path];
-}
-
 function flattenFields(
   value: unknown,
-  path: string = "",
+  segments: string[],
   depth: number = 0,
   outputFields: DetailField[] = [],
 ): void {
@@ -67,69 +49,31 @@ function flattenFields(
     return;
   }
 
+  const label = segments.join(".");
+
   if (Array.isArray(value)) {
-    outputFields.push({ path, kind: "array", count: value.length });
+    outputFields.push({ label, segments, kind: "array", count: value.length });
     return;
   }
 
   if (isPlainObject(value)) {
     if (depth >= MAX_DEPTH) {
       /* Too deep - bare path, full value available in Source */
-      outputFields.push({ path, kind: "object" });
+      outputFields.push({ label, segments, kind: "object" });
       return;
     }
 
     for (const [key, val] of Object.entries(value)) {
-      flattenFields(val, path ? `${path}.${key}` : key, depth + 1, outputFields);
+      flattenFields(val, [...segments, key], depth + 1, outputFields);
     }
 
     return;
-  }
-
-  if (typeof value === "string" && isLongStringField(path)) {
-    outputFields.push({
-      path,
-      kind: "long-string",
-      value,
-    });
-    return;
-  }
-
-  if (typeof value === "string" && isRuntimeExpressionField(path)) {
-    outputFields.push({
-      path,
-      kind: "runtime-expression",
-      value,
-    });
-    return;
-  }
-
-  if (typeof value === "string" && isDurationField(path)) {
-    outputFields.push({
-      path,
-      kind: "duration",
-      value,
-    });
-    return;
-  }
-
-  if (typeof value === "string") {
-    const options = getEnumOptions(path);
-
-    if (options) {
-      outputFields.push({
-        path,
-        kind: "enum",
-        value,
-        options,
-      });
-      return;
-    }
   }
 
   if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
     outputFields.push({
-      path,
+      label,
+      segments,
       kind: "scalar",
       value,
     });
@@ -147,32 +91,32 @@ export function getTaskDetails(task: Specification.Task): DetailField[] {
   // Handle timeout as it can be a string or an object (after)
   const timeoutSource =
     typeof record.timeout === "string"
-      ? { path: "timeout", value: record.timeout }
+      ? { segments: ["timeout"], value: record.timeout }
       : {
-          path: "timeout.after",
+          segments: ["timeout", "after"],
           value: nested("timeout")?.after,
         };
 
   /* Base fields, each labelled with its dsl path */
-  const baseSources: Array<{ path: string; value: unknown }> = [
-    { path: "if", value: record.if },
-    { path: "input.from", value: nested("input")?.from },
-    { path: "output.as", value: nested("output")?.as },
-    { path: "export.as", value: nested("export")?.as },
+  const baseSources: Array<{ segments: string[]; value: unknown }> = [
+    { segments: ["if"], value: record.if },
+    { segments: ["input", "from"], value: nested("input")?.from },
+    { segments: ["output", "as"], value: nested("output")?.as },
+    { segments: ["export", "as"], value: nested("export")?.as },
     timeoutSource,
-    { path: "then", value: record.then },
+    { segments: ["then"], value: record.then },
   ];
 
   const base: DetailField[] = [];
-  for (const { path, value } of baseSources) {
-    flattenFields(value, path, 0, base);
+  for (const { segments, value } of baseSources) {
+    flattenFields(value, segments, 0, base);
   }
 
   /* Top level keys (base keys and metadata excluded) */
   const specific: DetailField[] = [];
   for (const [key, value] of Object.entries(record)) {
     if (!TASK_BASE_KEYS.has(key)) {
-      flattenFields(value, key, 0, specific);
+      flattenFields(value, [key], 0, specific);
     }
   }
 

--- a/packages/open-workflow-diagram-editor/src/side-panel/EditableProperties.tsx
+++ b/packages/open-workflow-diagram-editor/src/side-panel/EditableProperties.tsx
@@ -98,13 +98,13 @@ export function EditableProperties({ fields, nodeId }: EditablePropertiesProps) 
         <FieldGroup className="dec-sidebar-edit-fields">
           {fields.map((field, index) => {
             if (field.kind !== "scalar") {
-              return <StaticPropertyRow key={field.label} field={field} />;
+              return <StaticPropertyRow key={draftName(index)} field={field} />;
             }
 
             const controlId = `${baseId}-${index}`;
 
             return (
-              <Field key={field.label}>
+              <Field key={draftName(index)}>
                 <label htmlFor={controlId} className="dec-sidebar-edit-field-label">
                   {field.label}
                 </label>
@@ -118,7 +118,7 @@ export function EditableProperties({ fields, nodeId }: EditablePropertiesProps) 
           {fields.map((field, index) =>
             field.kind === "scalar" ? (
               <button
-                key={field.label}
+                key={draftName(index)}
                 type="button"
                 className="dec-sidebar-prop dec-sidebar-prop-activator"
                 onClick={() => activateField(draftName(index))}
@@ -129,7 +129,7 @@ export function EditableProperties({ fields, nodeId }: EditablePropertiesProps) 
                 </span>
               </button>
             ) : (
-              <StaticPropertyRow key={field.label} field={field} />
+              <StaticPropertyRow key={draftName(index)} field={field} />
             ),
           )}
         </div>

--- a/packages/open-workflow-diagram-editor/src/side-panel/EditableProperties.tsx
+++ b/packages/open-workflow-diagram-editor/src/side-panel/EditableProperties.tsx
@@ -14,16 +14,126 @@
  * limitations under the License.
  */
 
+import * as React from "react";
+import { FormProvider, useForm } from "react-hook-form";
 import type { DetailField } from "@/core/taskDetails";
-import { ReadOnlyProperties } from "./ReadOnlyProperties";
+import { Field, FieldGroup } from "@/components/ui/field";
+import { FieldControl } from "./FieldControls";
+import { PropertyValue, StaticPropertyRow } from "./Fields";
 
 /**
- * Editable presentation of a task's properties.
+ * Editable presentation of a task's properties. Display when isReadOnly={false}
  *
- * PLACEHOLDER. This change establishes the read-only/edit seam only, so the editable
- * branch currently renders the same static rows as read-only mode until we implement
+ * By default this renders the same static rows as read-only mode; edit mode is entered deliberately, by clicking a row, which
+ * also focuses it.
  *
  */
-export function EditableProperties({ fields }: { fields: DetailField[] }) {
-  return <ReadOnlyProperties fields={fields} />;
+
+type EditablePropertiesProps = {
+  fields: DetailField[];
+  nodeId: string;
+};
+
+/* react-hook-form field names and the keys of the draft  */
+type DraftValues = Record<string, unknown>;
+
+/* A unique string per field (f0, f1 etc) */
+function draftName(index: number): string {
+  return `f${index}`;
+}
+
+/* Creates a field name for each and maps each fieldname to its current value. Allows RHF to track changes (only scaler for now) */
+function toDraftValues(fields: DetailField[]): DraftValues {
+  const values: DraftValues = {};
+
+  fields.forEach((field, index) => {
+    if (field.kind === "scalar") {
+      values[draftName(index)] = field.value;
+    }
+  });
+
+  return values;
+}
+
+export function EditableProperties({ fields, nodeId }: EditablePropertiesProps) {
+  const baseId = React.useId();
+  const [isEditing, setIsEditing] = React.useState(false);
+  const [fieldToFocus, setFieldToFocus] = React.useState<string | null>(null);
+
+  const form = useForm<DraftValues>({ defaultValues: toDraftValues(fields) });
+
+  /* Reset on node change rather than remounting behind a `key`: `useForm` lives above the
+     rows, so remounting them alone would leave the previous node's values in the draft. */
+  const renderedNodeId = React.useRef(nodeId);
+  React.useEffect(() => {
+    if (renderedNodeId.current === nodeId) {
+      return;
+    }
+
+    renderedNodeId.current = nodeId;
+    form.reset(toDraftValues(fields));
+    setIsEditing(false);
+    setFieldToFocus(null);
+  }, [nodeId, fields, form]);
+
+  /* Deferred to an effect because the control does not exist until edit mode has rendered. */
+  React.useEffect(() => {
+    if (!isEditing || fieldToFocus === null) {
+      return;
+    }
+
+    form.setFocus(fieldToFocus);
+    setFieldToFocus(null);
+  }, [isEditing, fieldToFocus, form]);
+
+  const activateField = (name: string) => {
+    form.reset(toDraftValues(fields));
+    setIsEditing(true);
+    setFieldToFocus(name);
+  };
+
+  return (
+    <FormProvider {...form}>
+      {isEditing ? (
+        <FieldGroup className="dec-sidebar-edit-fields">
+          {fields.map((field, index) => {
+            if (field.kind !== "scalar") {
+              return <StaticPropertyRow key={field.label} field={field} />;
+            }
+
+            const controlId = `${baseId}-${index}`;
+
+            return (
+              <Field key={field.label}>
+                <label htmlFor={controlId} className="dec-sidebar-edit-field-label">
+                  {field.label}
+                </label>
+                <FieldControl field={field} id={controlId} name={draftName(index)} />
+              </Field>
+            );
+          })}
+        </FieldGroup>
+      ) : (
+        <div className="dec-sidebar-props">
+          {fields.map((field, index) =>
+            field.kind === "scalar" ? (
+              <button
+                key={field.label}
+                type="button"
+                className="dec-sidebar-prop dec-sidebar-prop-activator"
+                onClick={() => activateField(draftName(index))}
+              >
+                <span className="dec-sidebar-prop-label">{field.label}</span>
+                <span className="dec-sidebar-prop-value">
+                  <PropertyValue field={field} />
+                </span>
+              </button>
+            ) : (
+              <StaticPropertyRow key={field.label} field={field} />
+            ),
+          )}
+        </div>
+      )}
+    </FormProvider>
+  );
 }

--- a/packages/open-workflow-diagram-editor/src/side-panel/FieldControls.tsx
+++ b/packages/open-workflow-diagram-editor/src/side-panel/FieldControls.tsx
@@ -15,122 +15,62 @@
  */
 
 import type { DetailField } from "@/core/taskDetails";
-import {
-  Combobox,
-  ComboboxContent,
-  ComboboxItem,
-  ComboboxList,
-  ComboboxTrigger,
-  ComboboxValue,
-} from "@/components/ui/combobox";
 import { Input } from "@/components/ui/input";
-import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
-import { useI18n } from "@openworkflowspec/i18n";
+import { Switch } from "@/components/ui/switch";
+import { Controller, useFormContext } from "react-hook-form";
 
-/**
- * These controls are read only presentation of a field and are always disabled.
- */
-type ControlProps<K extends DetailField["kind"]> = {
-  field: Extract<DetailField, { kind: K }>;
+export type EditableDetailField = Extract<DetailField, { kind: "scalar" }>;
+
+type ControlProps = {
+  id: string;
+  name: string;
 };
 
-const ISO_8601_DURATION_REGEX =
-  /^P(?=\d|T)(?:\d+Y)?(?:\d+M)?(?:\d+W)?(?:\d+D)?(?:T(?=\d)(?:\d+H)?(?:\d+M)?(?:\d+(?:\.\d+)?S)?)?$/;
-
-function LongStringControl({ field }: ControlProps<"long-string">) {
-  return <Textarea value={field.value} readOnly disabled />;
+function TextControl({ id, name }: ControlProps) {
+  const { register } = useFormContext();
+  return <Input id={id} {...register(name)} />;
 }
 
-function DurationControl({ field }: ControlProps<"duration">) {
-  const { t } = useI18n();
+/* A shell command or script body needs room to edit.*/
+function MultilineControl({ id, name }: ControlProps) {
+  const { register } = useFormContext();
+  return <Textarea id={id} rows={4} {...register(name)} />;
+}
+
+function NumberControl({ id, name }: ControlProps) {
+  const { register } = useFormContext();
+  return <Input id={id} type="number" {...register(name, { valueAsNumber: true })} />;
+}
+
+function BooleanControl({ id, name }: ControlProps) {
+  const { control } = useFormContext();
   return (
-    <Input
-      value={field.value}
-      pattern={ISO_8601_DURATION_REGEX.source}
-      title={t("sidebar.duration.title")}
-      disabled
+    <Controller
+      control={control}
+      name={name}
+      render={({ field: draft }) => (
+        <Switch
+          id={id}
+          ref={draft.ref}
+          checked={draft.value}
+          onCheckedChange={draft.onChange}
+          onBlur={draft.onBlur}
+        />
+      )}
     />
   );
 }
 
-function ExpressionControl({ field }: ControlProps<"runtime-expression">) {
-  return (
-    <div>
-      <span className="dec-sidebar-hint-text">Runtime expression</span>
-      <Input value={field.value} disabled />
-    </div>
-  );
-}
-
-function EnumControl({ field }: ControlProps<"enum">) {
-  return (
-    <Combobox value={field.value} disabled>
-      <ComboboxTrigger>
-        <ComboboxValue placeholder="Select an option" />
-      </ComboboxTrigger>
-      <ComboboxContent>
-        <ComboboxList>
-          {field.options.map((option) => (
-            <ComboboxItem key={option} value={option}>
-              {option}
-            </ComboboxItem>
-          ))}
-        </ComboboxList>
-      </ComboboxContent>
-    </Combobox>
-  );
-}
-
-function TextControl({ value }: { value: string }) {
-  return <Input value={value} disabled />;
-}
-
-function NumberControl({ value }: { value: number }) {
-  return <Input type="number" value={value} disabled />;
-}
-
-function BooleanControl({ value }: { value: boolean }) {
-  return <Switch checked={value} disabled />;
-}
-
-export function FieldControl({ field }: { field: DetailField }) {
-  const { t } = useI18n();
-
-  switch (field.kind) {
-    case "long-string":
-      return <LongStringControl field={field} />;
-
-    case "duration":
-      return <DurationControl field={field} />;
-
-    case "runtime-expression":
-      return <ExpressionControl field={field} />;
-
-    case "enum":
-      return <EnumControl field={field} />;
-
-    case "scalar":
-      if (typeof field.value === "string") {
-        return <TextControl value={field.value} />;
-      }
-
-      if (typeof field.value === "number") {
-        return <NumberControl value={field.value} />;
-      }
-
-      if (typeof field.value === "boolean") {
-        return <BooleanControl value={field.value} />;
-      }
-
-      return String(field.value);
-
-    case "array":
-      return `${field.count} ${t(
-        field.count === 1 ? "sidebar.field.item" : "sidebar.field.items",
-      )}`;
-
-    case "object":
-      return <>{"{...}"}</>;
+export function FieldControl({ field, ...rest }: ControlProps & { field: EditableDetailField }) {
+  if (typeof field.value === "number") {
+    return <NumberControl {...rest} />;
   }
+
+  if (typeof field.value === "boolean") {
+    return <BooleanControl {...rest} />;
+  }
+
+  /* TODO: once we have the schemas metadata, use it to decide if multiline or not instead of below */
+  return field.value.includes("\n") ? <MultilineControl {...rest} /> : <TextControl {...rest} />;
 }

--- a/packages/open-workflow-diagram-editor/src/side-panel/Fields.tsx
+++ b/packages/open-workflow-diagram-editor/src/side-panel/Fields.tsx
@@ -35,10 +35,10 @@ export function InlineField({ label, value }: { label: string; value: string }) 
   );
 }
 
-export function PropertyField({ label, field }: { label: string; field: DetailField }) {
+export function PropertyField({ field }: { field: DetailField }) {
   return (
     <div className="dec-sidebar-prop">
-      <dt className="dec-sidebar-prop-label">{label}</dt>
+      <dt className="dec-sidebar-prop-label">{field.label}</dt>
       <dd className="dec-sidebar-prop-value">
         <PropertyValue field={field} />
       </dd>
@@ -66,6 +66,17 @@ export function YamlField({ yaml, summary = "{...}" }: { yaml: string; summary?:
   );
 }
 
+export function StaticPropertyRow({ field }: { field: DetailField }) {
+  return (
+    <div className="dec-sidebar-prop dec-sidebar-prop-static">
+      <span className="dec-sidebar-prop-label">{field.label}</span>
+      <span className="dec-sidebar-prop-value">
+        <PropertyValue field={field} />
+      </span>
+    </div>
+  );
+}
+
 export function PropertyValue({ field }: { field: DetailField }) {
   const { t } = useI18n();
 
@@ -80,12 +91,10 @@ export function PropertyValue({ field }: { field: DetailField }) {
     case "object":
       return <span className="dec-sidebar-value-shape">{"{...}"}</span>;
 
-    /* A shell command or a script body, which can run to dozens of lines. Its own block,
-       capped and scrollable, so one long value cannot bury every row beneath it. */
-    case "long-string":
-      return <pre className="dec-sidebar-value-block">{field.value}</pre>;
-
     default: {
+      if (typeof field.value === "string" && field.value.includes("\n")) {
+        return <pre className="dec-sidebar-value-multiline">{field.value}</pre>;
+      }
       const numeric = typeof field.value === "number";
       return (
         <span className={numeric ? "dec-sidebar-value numeric" : "dec-sidebar-value"}>

--- a/packages/open-workflow-diagram-editor/src/side-panel/NodeDetailsView.tsx
+++ b/packages/open-workflow-diagram-editor/src/side-panel/NodeDetailsView.tsx
@@ -58,7 +58,7 @@ export function NodeDetailsView({ node }: NodeDetailsViewProps) {
           {isReadOnly ? (
             <ReadOnlyProperties fields={fields} />
           ) : (
-            <EditableProperties fields={fields} />
+            <EditableProperties fields={fields} nodeId={node.id} />
           )}
         </>
       )}

--- a/packages/open-workflow-diagram-editor/src/side-panel/SidePanel.css
+++ b/packages/open-workflow-diagram-editor/src/side-panel/SidePanel.css
@@ -186,6 +186,29 @@
     @apply dec:text-gray-100;
   }
 
+
+  .dec-root .dec-sidebar-prop-activator {
+    @apply dec:block dec:w-full dec:cursor-pointer dec:bg-transparent dec:text-left;
+  }
+
+  .dec-root .dec-sidebar-prop-activator:focus-visible {
+    outline: 1px solid rgb(var(--dec-selected-rgb));
+    outline-offset: -1px;
+  }
+
+  .dec-root .dec-sidebar-edit-fields {
+    @apply dec:gap-4 dec:py-1;
+  }
+
+  .dec-root .dec-sidebar-edit-field-label{
+    @apply dec:text-xs dec:font-normal dec:text-gray-500;
+    overflow-wrap: anywhere;
+  }
+
+    .dec-root.dark .dec-sidebar-edit-field-label{
+    @apply dec:text-gray-400;
+  }
+
   .dec-root .dec-sidebar-value {
     font-family: var(--dec-font-mono);
     overflow-wrap: anywhere;
@@ -205,7 +228,7 @@
 
   /* A shell command or a script body. Capped and scrollable so one thirty-line script cannot
      bury every row beneath it. */
-  .dec-root .dec-sidebar-value-block {
+  .dec-root .dec-sidebar-value-multiline {
     @apply dec:mt-0.5 dec:max-h-32 dec:overflow-auto dec:rounded-sm dec:bg-gray-100
       dec:px-2 dec:py-1.5 dec:text-xs dec:leading-relaxed dec:text-gray-800;
     font-family: var(--dec-font-mono);
@@ -213,7 +236,7 @@
     overflow-wrap: anywhere;
   }
 
-  .dec-root.dark .dec-sidebar-value-block {
+  .dec-root.dark .dec-sidebar-value-multiline {
     @apply dec:bg-gray-800/60 dec:text-gray-200;
   }
 

--- a/packages/open-workflow-diagram-editor/tests/core/taskDetails.test.ts
+++ b/packages/open-workflow-diagram-editor/tests/core/taskDetails.test.ts
@@ -30,9 +30,9 @@ describe("getTaskDetails", () => {
     );
 
     expect(fields).toEqual([
-      { path: "call", kind: "scalar", value: "http" },
-      { path: "with.method", kind: "scalar", value: "GET" },
-      { path: "with.url", kind: "scalar", value: "http://example.com" },
+      { label: "call", segments: ["call"], kind: "scalar", value: "http" },
+      { label: "with.method", segments: ["with", "method"], kind: "scalar", value: "GET" },
+      { label: "with.url", segments: ["with", "url"], kind: "scalar", value: "http://example.com" },
     ]);
   });
 
@@ -43,9 +43,9 @@ describe("getTaskDetails", () => {
     );
 
     expect(fields).toEqual([
-      { path: "set.foo", kind: "scalar", value: "bar" },
-      { path: "if", kind: "runtime-expression", value: "${ .ok }" },
-      { path: "then", kind: "scalar", value: "continue" },
+      { label: "set.foo", segments: ["set", "foo"], kind: "scalar", value: "bar" },
+      { label: "if", segments: ["if"], kind: "scalar", value: "${ .ok }" },
+      { label: "then", segments: ["then"], kind: "scalar", value: "continue" },
     ]);
   });
 
@@ -61,11 +61,16 @@ describe("getTaskDetails", () => {
     );
 
     expect(fields).toEqual([
-      { path: "set.x", kind: "scalar", value: 1 },
-      { path: "input.from", kind: "scalar", value: "${ .input }" },
-      { path: "output.as", kind: "scalar", value: "${ .output }" },
-      { path: "export.as", kind: "scalar", value: "${ .export }" },
-      { path: "timeout.after", kind: "duration", value: "${ .timeout }" },
+      { label: "set.x", segments: ["set", "x"], kind: "scalar", value: 1 },
+      { label: "input.from", segments: ["input", "from"], kind: "scalar", value: "${ .input }" },
+      { label: "output.as", segments: ["output", "as"], kind: "scalar", value: "${ .output }" },
+      { label: "export.as", segments: ["export", "as"], kind: "scalar", value: "${ .export }" },
+      {
+        label: "timeout.after",
+        segments: ["timeout", "after"],
+        kind: "scalar",
+        value: "${ .timeout }",
+      },
     ]);
   });
 
@@ -77,8 +82,18 @@ describe("getTaskDetails", () => {
     );
 
     expect(fields).toEqual([
-      { path: "timeout.after.minutes", kind: "scalar", value: 5 },
-      { path: "timeout.after.seconds", kind: "scalar", value: 30 },
+      {
+        label: "timeout.after.minutes",
+        segments: ["timeout", "after", "minutes"],
+        kind: "scalar",
+        value: 5,
+      },
+      {
+        label: "timeout.after.seconds",
+        segments: ["timeout", "after", "seconds"],
+        kind: "scalar",
+        value: 30,
+      },
     ]);
   });
 
@@ -89,7 +104,9 @@ describe("getTaskDetails", () => {
       }),
     );
 
-    expect(fields).toEqual([{ path: "timeout", kind: "duration", value: "MyTimeout" }]);
+    expect(fields).toEqual([
+      { label: "timeout", segments: ["timeout"], kind: "scalar", value: "MyTimeout" },
+    ]);
   });
 
   it.each([{ length: 0 }, { length: 1 }, { length: 2 }])(
@@ -100,7 +117,9 @@ describe("getTaskDetails", () => {
       }));
       const fields = getTaskDetails(asTask({ switch: items }));
 
-      expect(fields).toEqual([{ path: "switch", kind: "array", count: length }]);
+      expect(fields).toEqual([
+        { label: "switch", segments: ["switch"], kind: "array", count: length },
+      ]);
     },
   );
 
@@ -123,8 +142,17 @@ describe("getTaskDetails", () => {
     );
 
     expect(fields).toEqual([
-      { path: "with.a.b.client.name", kind: "scalar", value: "foo" },
-      { path: "with.a.b.client.config", kind: "object" },
+      {
+        label: "with.a.b.client.name",
+        segments: ["with", "a", "b", "client", "name"],
+        kind: "scalar",
+        value: "foo",
+      },
+      {
+        label: "with.a.b.client.config",
+        segments: ["with", "a", "b", "client", "config"],
+        kind: "object",
+      },
     ]);
   });
 
@@ -136,7 +164,7 @@ describe("getTaskDetails", () => {
       }),
     );
 
-    expect(fields).toEqual([{ path: "set.x", kind: "scalar", value: 1 }]);
+    expect(fields).toEqual([{ label: "set.x", segments: ["set", "x"], kind: "scalar", value: 1 }]);
   });
 
   it("returns no fields for a task with no displayable fields", () => {
@@ -154,7 +182,9 @@ describe("getTaskDetails", () => {
       }),
     );
 
-    expect(fields).toEqual([{ path: "set.c", kind: "scalar", value: "value" }]);
+    expect(fields).toEqual([
+      { label: "set.c", segments: ["set", "c"], kind: "scalar", value: "value" },
+    ]);
   });
 
   it("converts boolean values to text", () => {
@@ -168,8 +198,8 @@ describe("getTaskDetails", () => {
     );
 
     expect(fields).toEqual([
-      { path: "set.enabled", kind: "scalar", value: true },
-      { path: "set.disabled", kind: "scalar", value: false },
+      { label: "set.enabled", segments: ["set", "enabled"], kind: "scalar", value: true },
+      { label: "set.disabled", segments: ["set", "disabled"], kind: "scalar", value: false },
     ]);
   });
 
@@ -236,7 +266,7 @@ describe("getTaskDetails", () => {
       }),
     );
 
-    expect(fields).toEqual([{ path: "call", kind: "scalar", value: 123 }]);
+    expect(fields).toEqual([{ label: "call", segments: ["call"], kind: "scalar", value: 123 }]);
   });
 
   it("flattens fields exactly at the maximum supported depth", () => {
@@ -256,7 +286,8 @@ describe("getTaskDetails", () => {
 
     expect(fields).toEqual([
       {
-        path: "with.a.b.c.value",
+        label: "with.a.b.c.value",
+        segments: ["with", "a", "b", "c", "value"],
         kind: "scalar",
         value: "foo",
       },
@@ -277,12 +308,12 @@ describe("getTaskDetails", () => {
     );
 
     expect(fields).toEqual([
-      { path: "if", kind: "runtime-expression", value: "${ .condition }" },
-      { path: "input.from", kind: "scalar", value: "${ .input }" },
-      { path: "output.as", kind: "scalar", value: "${ .output }" },
-      { path: "export.as", kind: "scalar", value: "${ .export }" },
-      { path: "timeout", kind: "duration", value: "PT5M" },
-      { path: "then", kind: "scalar", value: "next" },
+      { label: "if", segments: ["if"], kind: "scalar", value: "${ .condition }" },
+      { label: "input.from", segments: ["input", "from"], kind: "scalar", value: "${ .input }" },
+      { label: "output.as", segments: ["output", "as"], kind: "scalar", value: "${ .output }" },
+      { label: "export.as", segments: ["export", "as"], kind: "scalar", value: "${ .export }" },
+      { label: "timeout", segments: ["timeout"], kind: "scalar", value: "PT5M" },
+      { label: "then", segments: ["then"], kind: "scalar", value: "next" },
     ]);
   });
 
@@ -297,74 +328,26 @@ describe("getTaskDetails", () => {
 
     expect(fields).toEqual([]);
   });
+});
 
-  it("classifies shell commands as long-string fields", () => {
-    const fields = getTaskDetails(
-      asTask({
-        run: {
-          shell: {
-            command: 'echo "Hello World"',
-          },
-        },
-      }),
-    );
+describe("DetailField.segments", () => {
+  it("carries the unflattened key path alongside the display label", () => {
+    const fields = getTaskDetails(asTask({ call: "http", with: { method: "GET" } }));
 
     expect(fields).toEqual([
-      {
-        path: "run.shell.command",
-        kind: "long-string",
-        value: 'echo "Hello World"',
-      },
+      { label: "call", segments: ["call"], kind: "scalar", value: "http" },
+      { label: "with.method", segments: ["with", "method"], kind: "scalar", value: "GET" },
     ]);
   });
 
-  it("classifies script code as a long-string field", () => {
-    const fields = getTaskDetails(
-      asTask({
-        run: {
-          script: {
-            code: 'console.log("Hello World");',
-          },
-        },
-      }),
-    );
+  /* `set` is an arbitrary-key map: the key is user text, not a schema property. A key that
+     itself contains a dot joins to a label indistinguishable from real nesting, so the
+     segments — not the label — are the source of truth for the real document shape. */
+  it("keeps a dotted arbitrary map key as a single segment", () => {
+    const fields = getTaskDetails(asTask({ set: { "user.name": "ada" } }));
 
     expect(fields).toEqual([
-      {
-        path: "run.script.code",
-        kind: "long-string",
-        value: 'console.log("Hello World");',
-      },
+      { label: "set.user.name", segments: ["set", "user.name"], kind: "scalar", value: "ada" },
     ]);
-  });
-
-  it("extracts enum fields with their available options", () => {
-    const fields = getTaskDetails({
-      call: "http",
-      with: {
-        method: "GET",
-        endpoint: "https://example.com",
-        output: "content",
-      },
-    });
-
-    expect(fields).toContainEqual({
-      path: "with.output",
-      kind: "enum",
-      value: "content",
-      options: ["raw", "content", "response"],
-    });
-  });
-
-  it("classifies timeout as a duration field", () => {
-    const task = {
-      timeout: "PT30S",
-    } as Specification.Task;
-
-    expect(getTaskDetails(task)).toContainEqual({
-      path: "timeout",
-      kind: "duration",
-      value: "PT30S",
-    });
   });
 });

--- a/packages/open-workflow-diagram-editor/tests/side-panel/EditableProperties.test.tsx
+++ b/packages/open-workflow-diagram-editor/tests/side-panel/EditableProperties.test.tsx
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2021-Present The Open Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { EditableProperties } from "../../src/side-panel/EditableProperties";
+import type { DetailField } from "../../src/core/taskDetails";
+import { renderWithProviders } from "../test-utils/render-helpers";
+import { scalarField } from "../test-utils/detail-fields";
+
+const callFields: DetailField[] = [scalarField("call", "http"), scalarField("with.method", "GET")];
+
+const renderEditable = (fields: DetailField[] = callFields, nodeId = "/do/fetchUser") =>
+  renderWithProviders(<EditableProperties fields={fields} nodeId={nodeId} />, {
+    isReadOnly: false,
+  });
+
+describe("EditableProperties", () => {
+  describe("default view (read only)", () => {
+    it("presents values statically rather than as form controls", () => {
+      renderEditable();
+
+      expect(screen.getByText("GET")).toBeInTheDocument();
+      expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    });
+
+    it("renders an editable row as a button", () => {
+      renderEditable();
+
+      expect(screen.getByRole("button", { name: /with\.method/ })).toBeInTheDocument();
+    });
+  });
+
+  describe("entering edit mode", () => {
+    it("turns every editable field into a control, not just the clicked one", async () => {
+      const user = userEvent.setup();
+      renderEditable();
+
+      await user.click(screen.getByText("GET"));
+
+      expect(screen.getByLabelText("call")).toHaveValue("http");
+      expect(screen.getByLabelText("with.method")).toHaveValue("GET");
+    });
+
+    it("focuses the clicked field so typing continues where the user pointed", async () => {
+      const user = userEvent.setup();
+      renderEditable();
+
+      await user.click(screen.getByText("GET"));
+
+      expect(screen.getByLabelText("with.method")).toHaveFocus();
+    });
+
+    it("focuses a clicked boolean row's switch", async () => {
+      const user = userEvent.setup();
+      renderEditable([scalarField("fork.compete", true)]);
+
+      await user.click(screen.getByText("true"));
+
+      expect(screen.getByRole("switch")).toHaveFocus();
+    });
+  });
+
+  describe("editing", () => {
+    it("holds typed input in the draft", async () => {
+      const user = userEvent.setup();
+      renderEditable();
+
+      await user.click(screen.getByText("GET"));
+      await user.clear(screen.getByLabelText("with.method"));
+      await user.type(screen.getByLabelText("with.method"), "POST");
+
+      expect(screen.getByLabelText("with.method")).toHaveValue("POST");
+    });
+
+    /* That a number survives as a number, rather than just looking numeric, is proved by the
+       submit round-trip in `FieldControls.test.tsx`. */
+    it("renders a number field as a number input", async () => {
+      const user = userEvent.setup();
+      renderEditable([scalarField("with.port", 8080)]);
+
+      await user.click(screen.getByText("8080"));
+
+      expect(screen.getByLabelText("with.port")).toHaveAttribute("type", "number");
+    });
+
+    it("edits a key that itself contains a dot", async () => {
+      const user = userEvent.setup();
+      renderEditable([scalarField("set.user.name", "ada", ["set", "user.name"])]);
+
+      await user.click(screen.getByText("ada"));
+      await user.clear(screen.getByLabelText("set.user.name"));
+      await user.type(screen.getByLabelText("set.user.name"), "grace");
+
+      expect(screen.getByLabelText("set.user.name")).toHaveValue("grace");
+    });
+  });
+
+  /* The form lives above the rendered rows, so a node switch must reset it explicitly —
+     remounting the rows alone would leave the previous node's values in the draft. */
+  describe("switching node", () => {
+    const otherNode = (
+      <EditableProperties fields={[scalarField("call", "grpc")]} nodeId="/do/other" />
+    );
+
+    it("shows the newly selected node's values", async () => {
+      const user = userEvent.setup();
+      const { rerender } = renderEditable();
+
+      await user.click(screen.getByText("GET"));
+      await user.clear(screen.getByLabelText("with.method"));
+      await user.type(screen.getByLabelText("with.method"), "POST");
+      rerender(otherNode);
+
+      expect(screen.getByText("grpc")).toBeInTheDocument();
+      expect(screen.queryByDisplayValue("POST")).not.toBeInTheDocument();
+    });
+
+    it("returns to the resting presentation", async () => {
+      const user = userEvent.setup();
+      const { rerender } = renderEditable();
+
+      await user.click(screen.getByText("GET"));
+      rerender(otherNode);
+
+      expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/open-workflow-diagram-editor/tests/side-panel/EditableProperties.test.tsx
+++ b/packages/open-workflow-diagram-editor/tests/side-panel/EditableProperties.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { EditableProperties } from "../../src/side-panel/EditableProperties";
@@ -98,15 +98,18 @@ describe("EditableProperties", () => {
       expect(screen.getByLabelText("with.port")).toHaveAttribute("type", "number");
     });
 
-    it("edits a key that itself contains a dot", async () => {
-      const user = userEvent.setup();
-      renderEditable([scalarField("set.user.name", "ada", ["set", "user.name"])]);
-
-      await user.click(screen.getByText("ada"));
-      await user.clear(screen.getByLabelText("set.user.name"));
-      await user.type(screen.getByLabelText("set.user.name"), "grace");
-
-      expect(screen.getByLabelText("set.user.name")).toHaveValue("grace");
+    it("keeps fields with the same label but different segments distinct", () => {
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+      renderEditable([
+        scalarField("set.user.name", "aaa", ["set", "user", "name"]),
+        scalarField("set.user.name", "bbb", ["set", "user.name"]),
+      ]);
+      expect(
+        consoleError.mock.calls.some(([message]) =>
+          String(message).includes("Encountered two children with the same key"),
+        ),
+      ).toBe(false);
+      consoleError.mockRestore();
     });
   });
 

--- a/packages/open-workflow-diagram-editor/tests/side-panel/FieldControls.test.tsx
+++ b/packages/open-workflow-diagram-editor/tests/side-panel/FieldControls.test.tsx
@@ -16,94 +16,99 @@
 
 import { describe, it, expect } from "vitest";
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FormProvider, useForm } from "react-hook-form";
 import { FieldControl } from "../../src/side-panel/FieldControls";
-import type { DetailField } from "../../src/core/taskDetails";
+import type { EditableDetailField } from "../../src/side-panel/FieldControls";
 import { renderWithProviders } from "../test-utils/render-helpers";
+import { scalarField } from "../test-utils/detail-fields";
+
+/* `FieldControl` is bound to the surrounding draft, so it only renders inside a form. . */
+const DRAFT_NAME = "f0";
+
+function SingleFieldForm({
+  field,
+  onValues,
+}: {
+  field: EditableDetailField;
+  onValues?: (v: unknown) => void;
+}) {
+  const form = useForm({ defaultValues: { [DRAFT_NAME]: field.value } });
+
+  return (
+    <FormProvider {...form}>
+      <form onSubmit={form.handleSubmit((values) => onValues?.(values))}>
+        <label htmlFor="control">{field.label}</label>
+        <FieldControl field={field} id="control" name={DRAFT_NAME} />
+        <button type="submit">submit</button>
+      </form>
+    </FormProvider>
+  );
+}
+
+const renderControl = (field: EditableDetailField, onValues?: (v: unknown) => void) =>
+  renderWithProviders(<SingleFieldForm field={field} onValues={onValues} />, { isReadOnly: false });
+
+const control = () => screen.getByLabelText("f");
+
+const field = (value: string | number | boolean) => scalarField("f", value) as EditableDetailField;
 
 describe("FieldControl", () => {
-  describe("scalar", () => {
-    const scalarCases: Array<[string, DetailField, string]> = [
-      ["string", { path: "call", kind: "scalar", value: "http" }, "http"],
-      ["number", { path: "with.port", kind: "scalar", value: 8080 }, "8080"],
-    ];
+  it("renders a string as a text input", () => {
+    renderControl(field("http"));
 
-    it.each(scalarCases)("renders a %s as a disabled input", (_label, field, displayed) => {
-      renderWithProviders(<FieldControl field={field} />);
-
-      const control = screen.getByDisplayValue(displayed);
-      expect(control.tagName).toBe("INPUT");
-      expect(control).toBeDisabled();
-    });
-
-    it("renders a number scalar as a number input", () => {
-      renderWithProviders(
-        <FieldControl field={{ path: "with.port", kind: "scalar", value: 8080 }} />,
-      );
-
-      expect(screen.getByDisplayValue("8080")).toHaveAttribute("type", "number");
-    });
-
-    it("renders a boolean as a disabled switch", () => {
-      renderWithProviders(
-        <FieldControl field={{ path: "fork.compete", kind: "scalar", value: true }} />,
-      );
-
-      const control = screen.getByRole("switch");
-      expect(control).toBeChecked();
-      expect(control).toBeDisabled();
-    });
+    expect(control().tagName).toBe("INPUT");
+    expect(control()).toHaveValue("http");
+    expect(control()).toBeEnabled();
   });
 
-  it("renders a long string as a disabled textarea", () => {
-    renderWithProviders(
-      <FieldControl field={{ path: "run.script.code", kind: "long-string", value: "echo hi" }} />,
-    );
+  it("renders a number as a number input", () => {
+    renderControl(field(8080));
 
-    const control = screen.getByDisplayValue("echo hi");
-    expect(control.tagName).toBe("TEXTAREA");
-    expect(control).toBeDisabled();
+    expect(control()).toHaveAttribute("type", "number");
   });
 
-  it("constrains a duration to the ISO 8601 format", () => {
-    renderWithProviders(
-      <FieldControl field={{ path: "timeout.after", kind: "duration", value: "PT5M" }} />,
-    );
+  it("submits an edited number as a number", async () => {
+    const user = userEvent.setup();
+    let submitted: unknown;
+    renderControl(field(8080), (v) => (submitted = v));
 
-    const control = screen.getByDisplayValue("PT5M");
-    expect(control).toBeDisabled();
-    expect(control).toHaveAttribute("pattern");
-    expect(control).toHaveAttribute("title", expect.stringContaining("ISO 8601"));
+    await user.clear(control());
+    await user.type(control(), "9090");
+    await user.click(screen.getByRole("button", { name: "submit" }));
+
+    expect(submitted).toEqual({ f0: 9090 });
   });
 
-  it("renders an enum as a combobox showing the selected option", () => {
-    renderWithProviders(
-      <FieldControl
-        field={{
-          path: "with.output",
-          kind: "enum",
-          value: "content",
-          options: ["raw", "content", "response"],
-        }}
-      />,
-    );
+  it("renders a boolean as a switch", () => {
+    renderControl(field(true));
 
-    expect(screen.getByText("content")).toBeInTheDocument();
+    expect(screen.getByRole("switch")).toBeChecked();
   });
 
-  /* Arrays and objects are not editable in the panel — they report their shape and the
-     full value stays available in the Source section. */
-  it.each([
-    [1, "1 item"],
-    [3, "3 items"],
-  ])("summarises an array of %i as %s", (count, expected) => {
-    renderWithProviders(<FieldControl field={{ path: "switch", kind: "array", count }} />);
+  it("submits a toggled boolean as a boolean", async () => {
+    const user = userEvent.setup();
+    let submitted: unknown;
+    renderControl(field(true), (v) => (submitted = v));
 
-    expect(screen.getByText(expected)).toBeInTheDocument();
+    await user.click(screen.getByRole("switch"));
+    await user.click(screen.getByRole("button", { name: "submit" }));
+
+    expect(submitted).toEqual({ f0: false });
   });
 
-  it("renders an object as a placeholder glyph", () => {
-    renderWithProviders(<FieldControl field={{ path: "with.headers", kind: "object" }} />);
+  /* A shell command or script body needs room. Chosen from the value being multi-line rather
+   than from its key, so it holds for any such string. */
+  it("renders a multi-line string as a textarea", () => {
+    renderControl(field("line one\nline two"));
 
-    expect(screen.getByText("{...}")).toBeInTheDocument();
+    expect(control().tagName).toBe("TEXTAREA");
+  });
+
+  it("renders a single-line string as a text input", () => {
+    renderControl(field("${ .ok }"));
+
+    expect(control().tagName).toBe("INPUT");
+    expect(control()).toHaveValue("${ .ok }");
   });
 });

--- a/packages/open-workflow-diagram-editor/tests/side-panel/FieldControls.test.tsx
+++ b/packages/open-workflow-diagram-editor/tests/side-panel/FieldControls.test.tsx
@@ -104,11 +104,4 @@ describe("FieldControl", () => {
 
     expect(control().tagName).toBe("TEXTAREA");
   });
-
-  it("renders a single-line string as a text input", () => {
-    renderControl(field("${ .ok }"));
-
-    expect(control().tagName).toBe("INPUT");
-    expect(control()).toHaveValue("${ .ok }");
-  });
 });

--- a/packages/open-workflow-diagram-editor/tests/side-panel/ReadOnlyProperties.test.tsx
+++ b/packages/open-workflow-diagram-editor/tests/side-panel/ReadOnlyProperties.test.tsx
@@ -19,6 +19,7 @@ import { screen } from "@testing-library/react";
 import { ReadOnlyProperties } from "../../src/side-panel/ReadOnlyProperties";
 import type { DetailField } from "../../src/core/taskDetails";
 import { renderWithProviders } from "../test-utils/render-helpers";
+import { arrayField, objectField, scalarField } from "../test-utils/detail-fields";
 
 const render = (...fields: DetailField[]) =>
   renderWithProviders(<ReadOnlyProperties fields={fields} />);
@@ -26,8 +27,8 @@ const render = (...fields: DetailField[]) =>
 describe("ReadOnlyProperties", () => {
   it("renders one labelled row per field", () => {
     const { container } = render(
-      { path: "call", kind: "scalar", value: "http" },
-      { path: "with.endpoint", kind: "scalar", value: "https://api.example.com" },
+      scalarField("call", "http"),
+      scalarField("with.endpoint", "https://api.example.com"),
     );
 
     expect(container.querySelectorAll(".dec-sidebar-prop")).toHaveLength(2);
@@ -35,47 +36,38 @@ describe("ReadOnlyProperties", () => {
     expect(screen.getByText("with.endpoint")).toBeInTheDocument();
   });
 
-  it.each([
-    ["scalar string", { path: "call", kind: "scalar", value: "http" }],
-    ["scalar number", { path: "with.port", kind: "scalar", value: 8080 }],
-    ["scalar boolean", { path: "fork.compete", kind: "scalar", value: true }],
-    ["enum", { path: "with.output", kind: "enum", value: "content", options: ["raw", "content"] }],
-    ["duration", { path: "timeout.after", kind: "duration", value: "PT5M" }],
-    ["runtime-expression", { path: "if", kind: "runtime-expression", value: "${ .ok }" }],
-    ["long-string", { path: "run.script.code", kind: "long-string", value: "echo hi" }],
-    ["array", { path: "switch", kind: "array", count: 3 }],
-    ["object", { path: "with.headers", kind: "object" }],
-  ] as Array<[string, DetailField]>)("renders no form control for a %s", (_label, field) => {
+  const everyKind: Array<[string, DetailField]> = [
+    ["scalar string", scalarField("call", "http")],
+    ["scalar number", scalarField("with.port", 8080)],
+    ["scalar boolean", scalarField("fork.compete", true)],
+    ["array", arrayField("switch", 3)],
+    ["object", objectField("with.headers")],
+  ];
+
+  it.each(everyKind)("renders no form control for a %s", (_label, field) => {
     const { container } = render(field);
 
     expect(container.querySelector("input, textarea, select, [role='switch']")).toBeNull();
   });
 
-  it.each([
-    ["a string", { path: "call", kind: "scalar", value: "http" }, "http"],
-    ["a number", { path: "with.port", kind: "scalar", value: 8080 }, "8080"],
-    ["a boolean as plain text", { path: "fork.compete", kind: "scalar", value: true }, "true"],
-    [
-      "an enum",
-      { path: "with.output", kind: "enum", value: "content", options: ["raw"] },
-      "content",
-    ],
-    ["a duration", { path: "timeout.after", kind: "duration", value: "PT5M" }, "PT5M"],
-    ["an expression", { path: "if", kind: "runtime-expression", value: "${ .ok }" }, "${ .ok }"],
-  ] as Array<[string, DetailField, string]>)(
-    "renders %s as its literal value",
-    (_l, field, text) => {
-      render(field);
+  const literalValues: Array<[string, DetailField, string]> = [
+    ["a string", scalarField("call", "http"), "http"],
+    ["a number", scalarField("with.port", 8080), "8080"],
+    ["a boolean as plain text", scalarField("fork.compete", true), "true"],
+    ["an expression", scalarField("if", "${ .ok }"), "${ .ok }"],
+  ];
 
-      expect(screen.getByText(text)).toBeInTheDocument();
-    },
-  );
+  it.each(literalValues)("renders %s as its literal value", (_l, field, text) => {
+    render(field);
+
+    expect(screen.getByText(text)).toBeInTheDocument();
+  });
 
   it("renders a long value in its own capped block", () => {
     const code = "const total = items.reduce((a, b) => a + b, 0);\nreturn total;";
-    const { container } = render({ path: "run.script.code", kind: "long-string", value: code });
+    const { container } = render(scalarField("run.script.code", code));
 
-    const block = container.querySelector(".dec-sidebar-value-block");
+    const block = container.querySelector(".dec-sidebar-value-multiline");
     expect(block).toBeInTheDocument();
     expect(block?.tagName).toBe("PRE");
     expect(block).toHaveTextContent("return total;");
@@ -86,13 +78,13 @@ describe("ReadOnlyProperties", () => {
     [1, "1 item"],
     [3, "3 items"],
   ])("summarises an array of %i as %s", (count, expected) => {
-    const { container } = render({ path: "switch", kind: "array", count });
+    const { container } = render(arrayField("switch", count));
 
     expect(container.querySelector(".dec-sidebar-value-shape")).toHaveTextContent(expected);
   });
 
   it("renders an object as a shape placeholder", () => {
-    const { container } = render({ path: "with.headers", kind: "object" });
+    const { container } = render(objectField("with.headers"));
 
     expect(container.querySelector(".dec-sidebar-value-shape")).toHaveTextContent("{...}");
   });

--- a/packages/open-workflow-diagram-editor/tests/test-utils/detail-fields.ts
+++ b/packages/open-workflow-diagram-editor/tests/test-utils/detail-fields.ts
@@ -14,18 +14,22 @@
  * limitations under the License.
  */
 
-import type { DetailField } from "@/core/taskDetails";
-import { PropertyField } from "./Fields";
+import { DetailField } from "../../src/core";
 
-/**
- * Static presentation of a task's flattened properties.
- */
-export function ReadOnlyProperties({ fields }: { fields: DetailField[] }) {
-  return (
-    <dl>
-      {fields.map((field) => (
-        <PropertyField key={field.label} field={field} />
-      ))}
-    </dl>
-  );
-}
+export const scalarField = (
+  label: string,
+  value: string | number | boolean,
+  segments: string[] = [label],
+): DetailField => ({ label, kind: "scalar", value, segments });
+
+export const arrayField = (
+  label: string,
+  count: number,
+  segments: string[] = [label],
+): DetailField => ({ label, kind: "array", count, segments });
+
+export const objectField = (label: string, segments: string[] = [label]): DetailField => ({
+  label,
+  kind: "object",
+  segments,
+});

--- a/packages/open-workflow-diagram-editor/tests/test-utils/render-helpers.tsx
+++ b/packages/open-workflow-diagram-editor/tests/test-utils/render-helpers.tsx
@@ -73,12 +73,13 @@ export const renderWithProviders = (
 ) => {
   const mockContext = createMockContextValue(contextValue);
 
-  return render(
+  const Providers = ({ children }: { children: React.ReactNode }) => (
     <DiagramEditorContext.Provider value={mockContext}>
       <I18nProvider locale={mockContext.locale} dictionaries={{ en }}>
-        <SidebarProvider defaultOpen={true}>{ui}</SidebarProvider>
+        <SidebarProvider defaultOpen={true}>{children}</SidebarProvider>
       </I18nProvider>
-    </DiagramEditorContext.Provider>,
-    renderOptions,
+    </DiagramEditorContext.Provider>
   );
+
+  return render(ui, { wrapper: Providers, ...renderOptions });
 };


### PR DESCRIPTION
### Summary

Closes https://github.com/open-workflow-specification/editor/issues/374

Foundation of form for node editing experience, added form and refactored field controls to use react-hook-form patterns. This is the first chunk of work, it is not a fully functioning editing form, we will build on this

### Changes
- Integrated field components with RHF and made foundational editing form
- Add shadcn `field` and `label` components
- Simplified and refactored field controls
- Refactor taskDetails to remove redundant logic for form components
- Add very basic styling for now (full styling with be addressed in separate issues)


In storybook, navigate to `Nested Editing` stories, click a node and click field

