### PR TITLE
feat: Add form footer and draft state

### DIFF
--- a/packages/open-workflow-diagram-editor/src/components/ui/shadcn.css
+++ b/packages/open-workflow-diagram-editor/src/components/ui/shadcn.css
@@ -25,6 +25,20 @@
 */
 
 .dec-root {
+  --primary: #2563eb;
+
+  --primary-foreground: #ffffff;
+
+  --background: hsl(0 0% 100%);
+
+  --border: hsl(220 13% 91%);
+
+  --input: hsl(220 13% 91%);
+
+  --accent: hsl(240 4.8% 95.9%);
+
+  --accent-foreground: hsl(240 5.9% 10%);
+
   --tooltip-background: hsl(0 0% 100%);
 
   --tooltip-foreground: hsl(222.2 84% 4.9%);
@@ -47,6 +61,20 @@
 }
 
 .dec-root.dark {
+  --primary: #2563eb;
+
+  --primary-foreground: #ffffff;
+
+  --background: var(--dec-surface-dark);
+
+  --border: var(--dec-surface-dark-line);
+
+  --input: var(--dec-surface-dark-line);
+
+  --accent: var(--dec-surface-dark-line);
+
+  --accent-foreground: hsl(0 0% 98%);
+
   --tooltip-background: hsl(222.2 84% 4.9%);
 
   --tooltip-foreground: hsl(210 40% 98%);
@@ -59,16 +87,30 @@
 
   --sidebar-primary-foreground: hsl(0 0% 100%);
 
-  --sidebar-accent: #3d4a5c;
+  --sidebar-accent: var(--dec-surface-dark-line);
 
   --sidebar-accent-foreground: hsl(240 4.8% 95.9%);
 
-  --sidebar-border: #3d4a5c;
+  --sidebar-border: var(--dec-surface-dark-line);
 
   --sidebar-ring: hsl(217.2 91.2% 59.8%);
 }
 
 @theme inline {
+  --color-primary: var(--primary);
+
+  --color-primary-foreground: var(--primary-foreground);
+
+  --color-background: var(--background);
+
+  --color-border: var(--border);
+
+  --color-input: var(--input);
+
+  --color-accent: var(--accent);
+
+  --color-accent-foreground: var(--accent-foreground);
+
   --color-tooltip-background: var(--tooltip-background);
   
   --color-tooltip-foreground: var(--tooltip-foreground);

--- a/packages/open-workflow-diagram-editor/src/core/index.ts
+++ b/packages/open-workflow-diagram-editor/src/core/index.ts
@@ -19,6 +19,7 @@ export * from "./workflowEditing";
 export * from "./validationErrors";
 export * from "./graph";
 export * from "./taskDetails";
+export * from "./taskDraft";
 export * from "./taskSubType";
 export * from "./elkjs";
 export * from "./mermaidExport";

--- a/packages/open-workflow-diagram-editor/src/core/taskDraft.ts
+++ b/packages/open-workflow-diagram-editor/src/core/taskDraft.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2021-Present The Open Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Specification } from "@openworkflowspec/sdk";
+
+/*
+ * This module bridges react-hook-form (which uses string field names) with nested task objects                                      
+ * (which have deep property paths). It solves a critical problem: react-hook-form interprets                                                                                                                  
+ * dots (.), brackets ([]), and slashes (/) as path separators, but workflow task properties  
+ * can contain these characters as literal parts of their keys.
+ */
+ 
+export type FieldChange = { segments: string[], value: unknown };
+
+const UNSAFE_SEGMENT_CHARS = /[%./[\]]/g;
+const ESCAPE_SEQUENCE = /%([0-9A-F]{2})/g;
+
+// Escapes special characters in a single path segment to prevent react-hook-form from misinterpreting them
+const encodeSegment = (segment: string): string =>
+    segment.replace(UNSAFE_SEGMENT_CHARS,(char) => `%${char.charCodeAt(0).toString(16).toUpperCase().padStart(2, "0")}`
+);
+
+// Reverses the encoding to get back the original key name
+const decodeSegment = (segment: string): string =>
+    segment.replace(ESCAPE_SEQUENCE,(_match, hex: string) =>
+    String.fromCharCode(Number.parseInt(hex, 16))
+);
+
+// Converts a property path array into a single encoded string for react-hook-form
+export function fieldName(segments: string[]): string {
+    return segments.map(encodeSegment).join("/");
+}
+
+// Converts an encoded field name back into the original property path array
+export function parseFieldName(name: string): string[] {
+    return name.split("/").map(decodeSegment);
+}
+
+// Writes a value to a deeply nested property path, creating intermediate objects as needed.
+function writeAtSegments(target: Record<string, unknown>, change: FieldChange): void {
+    const {segments, value} = change;
+    const leafKey = segments[segments.length - 1];
+
+    if(leafKey === undefined) {
+        return
+    }
+
+    let node = target
+
+    for (const segment of segments.slice(0, -1)) {
+        const next = node[segment]
+
+        if(Array.isArray(next)) {
+            // TODO not handled yet
+            throw new Error("array editing not implemented yet")
+        } 
+
+        if(typeof next !== "object" || next === null){
+            node[segment] = {}
+        }
+
+        node = node[segment] as Record<string, unknown>
+    }
+
+    if(value === undefined){
+        delete node[leafKey]
+        return
+    }
+
+    node[leafKey] = value
+}
+
+
+// Applies multiple field changes to a task, returning a new modified task
+export function applyFieldValues(task: Specification.Task, changes: FieldChange[]): Specification.Task {
+    const draft = structuredClone(task) as Record<string, unknown>
+
+    for(const change of changes) {
+        writeAtSegments(draft, change)
+    }
+
+    return draft as Specification.Task
+}

--- a/packages/open-workflow-diagram-editor/src/i18n/locales/en.ts
+++ b/packages/open-workflow-diagram-editor/src/i18n/locales/en.ts
@@ -58,6 +58,12 @@ export const en = {
   "sidebar.duration.title": "Enter an ISO 8601 duration, for example PT30S or PT5M",
   "sidebar.field.item": "item",
   "sidebar.field.items": "items",
+  "sidebar.form.apply": "Apply",
+  "sidebar.form.cancel": "Cancel",
+  "sidebar.form.changed": "changed",
+  "sidebar.form.noChanges": "No changes",
+  "sidebar.form.applied": "Applied",
+
 } as const;
 
 export type TranslationKeys = keyof typeof en;

--- a/packages/open-workflow-diagram-editor/src/side-panel/EditFormFooter.tsx
+++ b/packages/open-workflow-diagram-editor/src/side-panel/EditFormFooter.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import * as React from "react";
 import type * as RF from "@xyflow/react";
 import type { BaseNodeData } from "@/react-flow/nodes/Nodes";
 import { useI18n } from "@openworkflowspec/i18n";
@@ -22,15 +23,55 @@ import { Button } from "@/components/ui/button";
 import { useFormState } from "react-hook-form";
 import { updateTask } from "@/core/workflowEditing";
 import { useDiagramEditorContext } from "@/store/DiagramEditorContext";
+import { useEditSession } from "./EditSession";
+import { applyFieldValues, parseFieldName } from "@/core/taskDraft";
+import { Check } from "lucide-react";
+
+/* How long the applied message stays in footer */
+const APPLIED_MESSAGE_MS = 2400; 
+
+type DraftStatusProps ={
+  changedCount: number;
+  isDirty: boolean;
+  showApplied: boolean;
+}
+
+function DraftStatus({ changedCount, isDirty, showApplied }: DraftStatusProps) {
+  const {t} = useI18n();
+
+  const variant = isDirty? "changed": showApplied? "applied": "nochanges";
+  const label = variant === "changed" ? `${changedCount} ${t("sidebar.form.changed")}` : variant === "applied" ? t("sidebar.form.applied") : t("sidebar.form.noChanges");
+
+  return (
+    <span className={`dec-sidebar-form-footer-status ${variant}`} role="status">
+      {variant === "applied" ?(<Check className="dec-sidebar-form-footer-status-icon" aria-hidden="true" />): null}
+      {label}
+    </span>
+  );
+}
+
 
 
 export function EditFormFooter({ node }: { node: RF.Node<BaseNodeData> }) {
   const { t } = useI18n();
-const {form, isEditing, setIsEditing} = useEditSession()
-const {commitWorkflow, model} = useDiagramEditorContext()
+  const {form, isEditing, setIsEditing} = useEditSession()
+  const {commitWorkflow, isReadOnly, model} = useDiagramEditorContext()
+
+    const [appliedNodeId, setAppliedNodeId] = React.useState<string | null>(null);
+  const dismissTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  React.useEffect(() => () =>{
+    if(dismissTimer.current !== null) {
+      clearTimeout(dismissTimer.current);
+    }
+  }, []);
 
 const {dirtyFields, isDirty} = useFormState({ control: form.control });
 const task = node.data.task;
+
+if(isReadOnly || (!isEditing && !isDirty) || task === undefined || node.data.taskReference === undefined || model === null) {
+  return null;
+}
 
 const changedNames = Object.keys(dirtyFields);
 
@@ -40,6 +81,7 @@ const handleCancel = () => {
 };
 
 const handleApply = () => {
+  // TODO: Should add error handling if apply fails but first need to decide how to display that to the user before implementing
   const values = form.getValues()
   const changes = changedNames.map((name) => ({
    segments: parseFieldName(name),
@@ -49,16 +91,24 @@ const handleApply = () => {
   const updated = updateTask(model, node.id, applyFieldValues(task, changes));
   commitWorkflow(updated)
   form.reset(values);
+  setAppliedNodeId(node.id);
+
+  if(dismissTimer.current !== null) {
+    clearTimeout(dismissTimer.current);
+  } 
+
+  dismissTimer.current = setTimeout(() => setAppliedNodeId(null), APPLIED_MESSAGE_MS);
 };
+
   return (
       <SidebarFooter>
-        <div className="dec-sidebar-footer">
-          <span className="dec-sidebar-footer-count">{isDirty ? `${changedNames.length} ${t("sidebar.form.changed")}` : null}</span>
-          <div className="dec-sidebar-footer-actions">
+        <div className="dec-sidebar-form-footer">
+          <DraftStatus changedCount={changedNames.length} isDirty={isDirty} showApplied={appliedNodeId === node.id} />
+          <div className="dec-sidebar-form-footer-actions">
             <Button type="button" variant="outline" onClick={handleCancel}>
               {t("sidebar.form.cancel")}
             </Button>
-              <Button type="button" variant="outline" onClick={handleApply}>
+              <Button type="button" onClick={handleApply} disabled={!isDirty}>
               {t("sidebar.form.apply")}
             </Button>
           </div>

--- a/packages/open-workflow-diagram-editor/src/side-panel/EditFormFooter.tsx
+++ b/packages/open-workflow-diagram-editor/src/side-panel/EditFormFooter.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021-Present The Open Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type * as RF from "@xyflow/react";
+import type { BaseNodeData } from "@/react-flow/nodes/Nodes";
+import { useI18n } from "@openworkflowspec/i18n";
+import { SidebarFooter } from "@/components/ui/sidebar";
+import { Button } from "@/components/ui/button";
+import { useFormState } from "react-hook-form";
+import { updateTask } from "@/core/workflowEditing";
+import { useDiagramEditorContext } from "@/store/DiagramEditorContext";
+
+
+export function EditFormFooter({ node }: { node: RF.Node<BaseNodeData> }) {
+  const { t } = useI18n();
+const {form, isEditing, setIsEditing} = useEditSession()
+const {commitWorkflow, model} = useDiagramEditorContext()
+
+const {dirtyFields, isDirty} = useFormState({ control: form.control });
+const task = node.data.task;
+
+const changedNames = Object.keys(dirtyFields);
+
+const handleCancel = () => {
+  form.reset();
+  setIsEditing(false);
+};
+
+const handleApply = () => {
+  const values = form.getValues()
+  const changes = changedNames.map((name) => ({
+   segments: parseFieldName(name),
+   value: values[name],
+   }));
+
+  const updated = updateTask(model, node.id, applyFieldValues(task, changes));
+  commitWorkflow(updated)
+  form.reset(values);
+};
+  return (
+      <SidebarFooter>
+        <div className="dec-sidebar-footer">
+          <span className="dec-sidebar-footer-count">{isDirty ? `${changedNames.length} ${t("sidebar.form.changed")}` : null}</span>
+          <div className="dec-sidebar-footer-actions">
+            <Button type="button" variant="outline" onClick={handleCancel}>
+              {t("sidebar.form.cancel")}
+            </Button>
+              <Button type="button" variant="outline" onClick={handleApply}>
+              {t("sidebar.form.apply")}
+            </Button>
+          </div>
+        </div>
+      </SidebarFooter>
+  );
+}

--- a/packages/open-workflow-diagram-editor/src/side-panel/EditSession.tsx
+++ b/packages/open-workflow-diagram-editor/src/side-panel/EditSession.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021-Present The Open Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+import { FormProvider, useForm, type UseFormReturn } from "react-hook-form";
+
+export type DraftValues = Record<string, unknown>;
+
+type EditSessionValue = {
+    form: UseFormReturn<DraftValues>;
+    isEditing: boolean;
+    setIsEditing: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const EditSessionContext = React.createContext<EditSessionValue | undefined>(undefined);
+
+export function EditSessionProvider({ children }: { children: React.ReactNode }) {
+    const form = useForm<DraftValues>({ defaultValues: {}});
+    const [isEditing, setIsEditing] = React.useState(false);
+
+    const value = React.useMemo(() => ({ form, isEditing, setIsEditing }), [form, isEditing]);
+
+    return (<EditSessionContext.Provider value={value}>{<FormProvider {...form}>{children}</FormProvider>}</EditSessionContext.Provider>)
+
+}
+
+export function useEditSession() {
+    const context = React.useContext(EditSessionContext);
+    if (!context) {
+        throw new Error("useEditSession must be used within an EditSessionProvider");
+    }
+    return context;
+}

--- a/packages/open-workflow-diagram-editor/src/side-panel/EditableProperties.tsx
+++ b/packages/open-workflow-diagram-editor/src/side-panel/EditableProperties.tsx
@@ -15,11 +15,12 @@
  */
 
 import * as React from "react";
-import { FormProvider, useForm } from "react-hook-form";
 import type { DetailField } from "@/core/taskDetails";
 import { Field, FieldGroup } from "@/components/ui/field";
 import { FieldControl } from "./FieldControls";
 import { PropertyValue, StaticPropertyRow } from "./Fields";
+import {useEditSession, type DraftValues} from "./EditSession";
+import { fieldName } from "@/core/taskDraft";
 
 /**
  * Editable presentation of a task's properties. Display when isReadOnly={false}
@@ -34,37 +35,28 @@ type EditablePropertiesProps = {
   nodeId: string;
 };
 
-/* react-hook-form field names and the keys of the draft  */
-type DraftValues = Record<string, unknown>;
-
-/* A unique string per field (f0, f1 etc) */
-function draftName(index: number): string {
-  return `f${index}`;
-}
 
 /* Creates a field name for each and maps each fieldname to its current value. Allows RHF to track changes (only scaler for now) */
 function toDraftValues(fields: DetailField[]): DraftValues {
   const values: DraftValues = {};
 
-  fields.forEach((field, index) => {
+  for (const field of fields) {
     if (field.kind === "scalar") {
-      values[draftName(index)] = field.value;
+      values[fieldName(field.segments)] = field.value;
     }
-  });
+  };
 
   return values;
 }
 
 export function EditableProperties({ fields, nodeId }: EditablePropertiesProps) {
   const baseId = React.useId();
-  const [isEditing, setIsEditing] = React.useState(false);
+  const {form, isEditing, setIsEditing} = useEditSession();
   const [fieldToFocus, setFieldToFocus] = React.useState<string | null>(null);
-
-  const form = useForm<DraftValues>({ defaultValues: toDraftValues(fields) });
 
   /* Reset on node change rather than remounting behind a `key`: `useForm` lives above the
      rows, so remounting them alone would leave the previous node's values in the draft. */
-  const renderedNodeId = React.useRef(nodeId);
+  const renderedNodeId = React.useRef<string | null>(null);
   React.useEffect(() => {
     if (renderedNodeId.current === nodeId) {
       return;
@@ -74,7 +66,7 @@ export function EditableProperties({ fields, nodeId }: EditablePropertiesProps) 
     form.reset(toDraftValues(fields));
     setIsEditing(false);
     setFieldToFocus(null);
-  }, [nodeId, fields, form]);
+  }, [nodeId, fields, form, setIsEditing]);
 
   /* Deferred to an effect because the control does not exist until edit mode has rendered. */
   React.useEffect(() => {
@@ -87,41 +79,44 @@ export function EditableProperties({ fields, nodeId }: EditablePropertiesProps) 
   }, [isEditing, fieldToFocus, form]);
 
   const activateField = (name: string) => {
+    if(!isEditing) {
     form.reset(toDraftValues(fields));
     setIsEditing(true);
+    }
+
     setFieldToFocus(name);
   };
 
   return (
-    <FormProvider {...form}>
+    <>
       {isEditing ? (
         <FieldGroup className="dec-sidebar-edit-fields">
           {fields.map((field, index) => {
             if (field.kind !== "scalar") {
-              return <StaticPropertyRow key={draftName(index)} field={field} />;
+              return <StaticPropertyRow key={fieldName(field.segments)} field={field} />;
             }
 
             const controlId = `${baseId}-${index}`;
 
             return (
-              <Field key={draftName(index)}>
+              <Field key={fieldName(field.segments)}>
                 <label htmlFor={controlId} className="dec-sidebar-edit-field-label">
                   {field.label}
                 </label>
-                <FieldControl field={field} id={controlId} name={draftName(index)} />
+                <FieldControl field={field} id={controlId} name={fieldName(field.segments)} />
               </Field>
             );
           })}
         </FieldGroup>
       ) : (
         <div className="dec-sidebar-props">
-          {fields.map((field, index) =>
+          {fields.map((field) =>
             field.kind === "scalar" ? (
               <button
-                key={draftName(index)}
+                key={fieldName(field.segments)}
                 type="button"
                 className="dec-sidebar-prop dec-sidebar-prop-activator"
-                onClick={() => activateField(draftName(index))}
+                onClick={() => activateField(fieldName(field.segments))}
               >
                 <span className="dec-sidebar-prop-label">{field.label}</span>
                 <span className="dec-sidebar-prop-value">
@@ -129,11 +124,11 @@ export function EditableProperties({ fields, nodeId }: EditablePropertiesProps) 
                 </span>
               </button>
             ) : (
-              <StaticPropertyRow key={draftName(index)} field={field} />
+              <StaticPropertyRow key={fieldName(field.segments)} field={field} />
             ),
           )}
         </div>
       )}
-    </FormProvider>
+    </>
   );
 }

--- a/packages/open-workflow-diagram-editor/src/side-panel/SidePanel.css
+++ b/packages/open-workflow-diagram-editor/src/side-panel/SidePanel.css
@@ -195,6 +195,69 @@
     outline: 1px solid rgb(var(--dec-selected-rgb));
     outline-offset: -1px;
   }
+    /* End Property row */
+
+  /* Sidebar Footer */
+  .dec-root .dec-sidebar-form-footer{
+    @apply dec:-mx-2 dec:-mt-2 dec:flex dec:items-center dec:justify-between dec:gap-2 dec:border-t dec:border-gray-200 dec:px-3 dec:py-3;
+  }
+
+  .dec-root.dark .dec-sidebar-form-footer{
+    @apply dec:border-gray-700;
+  }
+
+  .dec-root .dec-sidebar-form-footer-status{
+    @apply dec:flex dec:min-w-0 dec:items-center dec:gap-1 dec:overflow-hidden dec:whitespace-nowrap dec:text-xs dec:font-medium;
+  }
+
+  .dec-root .dec-sidebar-form-footer-status.changed{
+    color: var(--dec-accent-text);
+  }
+
+  .dec-root .dec-sidebar-form-footer-status.applied{
+    color: var(--dec-success-text);
+    animation: dec-sidebar-status-in 140ms ease-out;
+  }
+
+  .dec-root .dec-sidebar-form-footer-status.nochanges{
+    @apply dec:font-normal dec:text-gray-500;
+  }
+
+  .dec-root.dark .dec-sidebar-form-footer-status.nochanges{
+    @apply dec:text-gray-400;
+  }
+
+  .dec-root.dark .dec-sidebar-form-footer-status-icon{
+    @apply dec:h-3.5 dec:w-3.5 dec:shrink-0;
+  }
+
+  @keyframes dec-sidebar-status-in {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+
+  @media (prefers-reduced-motion:reduce) {
+    .dec-root .dec-sidebar-form-footer-status.applied{
+      animation: none;
+    }
+  }
+
+  .dec-root .dec-sidebar-form-footer-actions{
+    @apply dec:flex dec:shrink-0 dec:items-center dec:gap-2;
+  }
+
+  .dec-root .dec-sidebar-form-footer-count{
+    @apply dec:min-w-0 dec:truncate dec:text-xs dec:font-medium dec:text-blue-600;
+  }
+
+  .dec-root.dark .dec-sidebar-form-footer-count{
+    @apply dec:text-blue-400;
+  }
+  /* End Sidebar Footer */
 
   .dec-root .dec-sidebar-edit-fields {
     @apply dec:gap-4 dec:py-1;

--- a/packages/open-workflow-diagram-editor/src/side-panel/SidePanel.tsx
+++ b/packages/open-workflow-diagram-editor/src/side-panel/SidePanel.tsx
@@ -32,6 +32,8 @@ import { MermaidActions } from "@/side-panel/MermaidActions";
 import { getNodeVisualConfig } from "@/react-flow/nodes/taskNodeConfig";
 import type { BaseNodeData } from "@/react-flow/nodes/Nodes";
 import "./SidePanel.css";
+import { EditSessionProvider } from "./EditSession";
+import { EditFormFooter } from "./EditFormFooter";
 
 export function SidePanel() {
   const { model, nodes, selectedNodeId } = useDiagramEditorContext();
@@ -66,6 +68,7 @@ export function SidePanel() {
       aria-label={selectedNode ? t("aria.panel.nodeDetails") : t("aria.panel.workflowInfo")}
       role="complementary"
     >
+      <EditSessionProvider>
       <SidebarHeader>
         <div className="dec-sidebar-header-title">
           <span
@@ -107,6 +110,8 @@ export function SidePanel() {
           <MermaidActions model={model} />
         </SidebarFooter>
       ) : null}
+      { selectedNode !== null ? <EditFormFooter node={selectedNode} /> : null }
+      </EditSessionProvider>
     </Sidebar>
   );
 }

--- a/packages/open-workflow-diagram-editor/src/store/DiagramEditorContext.tsx
+++ b/packages/open-workflow-diagram-editor/src/store/DiagramEditorContext.tsx
@@ -54,6 +54,8 @@ export type DiagramEditorContextType = {
    * `getContent()` calls.
    */
   setContent: (content: string) => void;
+  /* Editor originated changes*/
+  commitWorkflow: (workflow: Specification.Workflow) => void;
 };
 
 export const DiagramEditorContext = React.createContext<DiagramEditorContextType | undefined>(

--- a/packages/open-workflow-diagram-editor/src/store/DiagramEditorContextProvider.tsx
+++ b/packages/open-workflow-diagram-editor/src/store/DiagramEditorContextProvider.tsx
@@ -21,6 +21,7 @@ import {
   getTaskReferences,
   parseWorkflow,
   serializeWorkflow,
+  validateWorkflow,
 } from "../core";
 import type { Specification } from "@openworkflowspec/sdk";
 import { DiagramEditorProps, DiagramEditorRef } from "../diagram-editor/DiagramEditor";
@@ -146,6 +147,17 @@ export const DiagramEditorContextProvider = React.forwardRef<
     [seedModel],
   );
 
+  const commitWorkflow = React.useCallback(
+    (workflow: Specification.Workflow) => {
+      // TODO: Temporary - Errors still computed here by validating full workflow, Open question on how to tackle this - a form knows about one task, but these areas are for entire workflow
+      setErrors(validateWorkflow(workflow));
+      const resolvedId = resolveSelectedId(workflow, selectedNodeIdRef.current);
+      setSelectedNodeId(resolvedId);
+      seedModel(workflow, { x: 0, y: 0, zoom: 1 }, resolvedId);
+    },
+    [seedModel]
+  );
+
   // Bind setSelectedNodeId into undo/redo wrappers via direct callback.
   // This keeps selection restore atomic with the history dispatch.
   const undo = React.useCallback(() => {
@@ -191,7 +203,8 @@ export const DiagramEditorContextProvider = React.forwardRef<
       pendingViewportRestore,
       clearPendingViewportRestore,
       setContent,
-    }),
+      commitWorkflow,
+}),
     [
       isReadOnly,
       locale,
@@ -214,6 +227,7 @@ export const DiagramEditorContextProvider = React.forwardRef<
       pendingViewportRestore,
       clearPendingViewportRestore,
       setContent,
+      commitWorkflow
     ],
   );
 

--- a/packages/open-workflow-diagram-editor/src/styles.css
+++ b/packages/open-workflow-diagram-editor/src/styles.css
@@ -62,6 +62,10 @@
     /* Selection / focus accent - (node rings, edge glow, condition-edge stroke, minimap viewport) */
     --dec-selected-rgb: 59 130 246;
 
+    --dec-accent-text: #2563eb;
+
+    --dec-success-text: #047857;
+
     /* node hover glow */
     --dec-node-hover-glow: rgba(0, 65, 208, 0.3);
 
@@ -69,6 +73,7 @@
     --dec-surface-dark: #1a202c;
     --dec-surface-dark-raised: #1f2937;
     --dec-surface-dark-elevated: #2d3748;
+    --dec-surface-dark-line: #3d4a5c;
 
     /* edges */
     --dec-edge-selected: #aea6a6;
@@ -104,6 +109,8 @@
     
     --dec-edge-selected: #aea6a6;
     --dec-selected-rgb: 96 165 250;
+    --dec-accent-text: #60a5fa;
+    --dec-success-text: #34d399;
     --dec-edge-selected-condition: rgb(var(--dec-selected-rgb));
     --dec-node-hover-glow: rgba(255, 255, 255, 0.3);
 

--- a/packages/open-workflow-diagram-editor/tests/core/taskDraft.test.ts
+++ b/packages/open-workflow-diagram-editor/tests/core/taskDraft.test.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2021-Present The Open Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { Specification } from "@openworkflowspec/sdk";
+import { applyFieldValues, fieldName, parseFieldName } from "../../src/core/taskDraft";
+
+const asTask = (value: Record<string, unknown>): Specification.Task =>
+  value as unknown as Specification.Task;
+
+describe("fieldName", () => {
+  it("joins segments with a slash", () => {
+    expect(fieldName(["with", "endpoint"])).toBe("with/endpoint");
+  });
+
+  /* react-hook-form reads `.` and `[` as path syntax, so a user-authored key
+     containing one must never reach it unescaped. */
+  it.each([
+    ["a dot", ["set", "user.name"], "set/user%2Ename"],
+    ["a slash", ["with", "headers", "text/plain"], "with/headers/text%2Fplain"],
+    ["a bracket", ["metadata", "a[0]"], "metadata/a%5B0%5D"],
+    ["a percent", ["metadata", "100%"], "metadata/100%25"],
+  ])("escapes %s", (_label, segments, expected) => {
+    expect(fieldName(segments)).toBe(expected);
+  });
+
+  it.each([
+    ["plain", ["with", "endpoint"]],
+    ["dots", ["set", "user.name"]],
+    ["slashes", ["with", "headers", "text/plain"]],
+    ["brackets", ["metadata", "a[0]"]],
+    ["percents", ["metadata", "100%"]],
+    ["an escape sequence written literally", ["metadata", "%2E"]],
+  ])("round-trips segments containing %s", (_label, segments) => {
+    expect(parseFieldName(fieldName(segments))).toEqual(segments);
+  });
+});
+
+describe("applyFieldValues", () => {
+  const task = () =>
+    asTask({
+      call: "http",
+      with: {
+        endpoint: "https://api.example.com",
+        method: "GET",
+        headers: { Accept: "application/json" },
+      },
+      metadata: { owner: "payments" },
+      export: { as: "." },
+    });
+
+  it("writes every change in one pass, at the key path each addresses", () => {
+    const result = applyFieldValues(task(), [
+      { segments: ["call"], value: "openapi" },
+      { segments: ["with", "method"], value: "POST" },
+    ])
+
+    expect(result.call).toBe("openapi");
+    expect((result.with as Record<string, unknown>).method).toBe("POST");
+  });
+
+  it("creates missing intermediate objects", () => {
+    const result = applyFieldValues(task(), [
+      { segments: ["timeout", "after"], value: "PT30S" },
+    ]) as Record<string, Record<string, unknown>>;
+
+    expect(result.timeout!.after).toBe("PT30S");
+  });
+
+  /* getTaskDetails drops arrays, deep objects and metadata for now — so a
+     task rebuilt from the visible rows alone would silently delete them. */
+  it("preserves fields that no change mentions", () => {
+    const result = applyFieldValues(task(), [
+      { segments: ["with", "method"], value: "POST" },
+    ]) as Record<string, Record<string, unknown>>;
+
+    expect(result.metadata).toEqual({ owner: "payments" });
+    expect(result.with!.headers).toEqual({ Accept: "application/json" });
+    expect(result.export).toEqual({ as: "." });
+  });
+
+  it("does not mutate the source task", () => {
+    const source = task();
+
+    applyFieldValues(source, [{ segments: ["with", "method"], value: "POST" }]);
+
+    expect((source as unknown as Record<string, Record<string, unknown>>).with!.method).toBe("GET");
+  });
+
+  /* A port written as "1433" must not come back as the number 1433. */
+  it("writes values at their given type", () => {
+    const result = applyFieldValues(task(), [
+      { segments: ["with", "port"], value: "1433" },
+      { segments: ["with", "retries"], value: 3 },
+      { segments: ["with", "redirect"], value: false },
+    ]) as Record<string, Record<string, unknown>>;
+
+    expect(result.with!.port).toBe("1433");
+    expect(result.with!.retries).toBe(3);
+    expect(result.with!.redirect).toBe(false);
+  });
+
+  it("removes the key when the value is undefined", () => {
+    const result = applyFieldValues(task(), [
+      { segments: ["with", "method"], value: undefined },
+    ]) as Record<string, Record<string, unknown>>;
+
+    expect("method" in result.with!).toBe(false);
+    expect(result.with!.endpoint).toBe("https://api.example.com");
+  });
+});
+

--- a/packages/open-workflow-diagram-editor/tests/fixtures/workflows.ts
+++ b/packages/open-workflow-diagram-editor/tests/fixtures/workflows.ts
@@ -526,3 +526,44 @@ export const PARSEABLE_INVALID_WORKFLOW_YAML = `
               while: .vet != null
               do:
   `;
+/**
+ * A try/catch task, with a named error variable and a recovery task list.
+ *
+ * Exported separately from the workflow below because the side panel's tests need the task
+ * on its own: a try/catch's TRY and CATCH frames are handed the parent task to display
+ * under an id that addresses no task of their own.
+ */
+export const TRY_CATCH_TASK = {
+  try: [{ fetchPreferences: { call: "http", with: { endpoint: "https://api.example.com" } } }],
+  catch: {
+    errors: { with: { status: 404 } },
+    as: "error",
+    do: [{ setDefaults: { set: { theme: "default" } } }],
+  },
+};
+
+/**
+ * A workflow covering every container kind — fork, for, try/catch and do — one task each.
+ */
+export const NESTED_CONTAINERS_WORKFLOW = {
+  document: { dsl: "1.0.3", name: "nested", version: "1.0.0", namespace: "default" },
+  do: [
+    {
+      forkTask: {
+        fork: {
+          branches: [
+            { notifyEmail: { call: "http", with: { endpoint: "https://mail.example.com" } } },
+          ],
+        },
+      },
+    },
+    {
+      forTask: {
+        for: { each: "user", in: "${ .users }" },
+        do: [{ assignRole: { set: { role: "admin" } } }],
+      },
+    },
+    { tryTask: TRY_CATCH_TASK },
+    { doTask: { do: [{ storeProfile: { set: { stored: true } } }] } },
+  ],
+};

--- a/packages/open-workflow-diagram-editor/tests/react-flow/diagram/diagramBuilder.test.ts
+++ b/packages/open-workflow-diagram-editor/tests/react-flow/diagram/diagramBuilder.test.ts
@@ -29,12 +29,14 @@ import {
   TERMINAL_NODE_SIZE,
   getNodeSize,
 } from "../../../src/react-flow/diagram/autoLayout";
-import { parseWorkflow, type SdkError } from "../../../src/core";
+import { parseWorkflow, updateTask, type SdkError } from "../../../src/core";
 import {
   BASIC_VALID_WORKFLOW_JSON,
   BASIC_VALID_WORKFLOW_JSON_TASKS,
+  NESTED_CONTAINERS_WORKFLOW,
 } from "../../fixtures/workflows";
 import { createFlatGraph } from "../../test-utils/graph-helpers";
+import { parseFixture } from "../../test-utils/workflow-helpers";
 import { CATCH_CONTAINER_NODE_TYPE } from "../../../src/react-flow/nodes/taskNodeConfig";
 
 // Type alias for diagram elements to reduce verbosity
@@ -611,7 +613,7 @@ describe("diagramBuilder", () => {
       /* Errors are matched against the node's taskReference (indexed JSON pointer) */
       const target = baseline.nodes.find((node) => node.data.taskReference !== undefined)!;
       const targetId = target.id;
-      const targetReference = target.data.taskReference!;
+      const targetReference = target.data.taskReference as string;
 
       it("does not set hasError on any node when no errors are passed", () => {
         const diagram = buildDiagramElements(model);
@@ -984,4 +986,35 @@ describe("diagramBuilder", () => {
       expect(result.size).toBe(2);
     });
   });
+
+ describe("editable node ids", () => {
+   const model = parseFixture(NESTED_CONTAINERS_WORKFLOW);
+   const diagram = buildDiagramElements(model);
+
+
+   it("resolves every node the panel treats as an editable task", () => {
+     const editableIds = diagram.nodes
+       .filter((node) => node.data.taskReference !== undefined)
+       .map((node) => node.id);
+
+
+     expect(editableIds.length).toBeGreaterThan(0);
+     for (const id of editableIds) {
+       expect(() => updateTask(model, id, { set: { touched: true } })).not.toThrow();
+     }
+   });
+
+
+   it("withholds the editable marker from container frames, whose ids address no task", () => {
+     const frameIds = diagram.nodes
+       .filter((node) => node.data.task !== undefined && node.data.taskReference === undefined)
+       .map((node) => node.id);
+
+
+     expect(frameIds).toEqual(["/do/tryTask/try", "/do/tryTask/catch/do"]);
+     for (const id of frameIds) {
+       expect(() => updateTask(model, id, { set: { touched: true } })).toThrow(/Task not found/);
+     }
+   });
+ });
 });

--- a/packages/open-workflow-diagram-editor/tests/side-panel/EditFormFooter.test.tsx
+++ b/packages/open-workflow-diagram-editor/tests/side-panel/EditFormFooter.test.tsx
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2021-Present The Open Workflow Specification Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+import { act, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type * as RF from "@xyflow/react";
+import type { Specification } from "@openworkflowspec/sdk";
+import { EditFormFooter } from "../../src/side-panel/EditFormFooter";
+import { EditableProperties } from "../../src/side-panel/EditableProperties";
+import { getTaskDetails } from "../../src/core";
+import type { BaseNodeData } from "../../src/react-flow/nodes/Nodes";
+import { MANAGING_GITHUB_ISSUES_WORKFLOW, TRY_CATCH_TASK } from "../fixtures/workflows";
+import { renderWithProviders } from "../test-utils/render-helpers";
+import { nodeAt, parseFixture } from "../test-utils";
+
+const NODE_ID = "/do/evaluateReview/do/closeIssue/do/closeIssueOnGithub";
+const model = parseFixture(MANAGING_GITHUB_ISSUES_WORKFLOW);
+
+const node = nodeAt(model, NODE_ID);
+const task = node.data.task!;
+
+const renderFooter = (overrides = {}) => {
+  const commitWorkflow = vi.fn();
+
+  renderWithProviders(
+    <>
+      <EditableProperties fields={getTaskDetails(task)} nodeId={NODE_ID} />
+      <EditFormFooter node={node} />
+    </>,
+    { isReadOnly: false, contentFormat: "json", model, commitWorkflow, ...overrides },
+  );
+
+  return { commitWorkflow };
+};
+
+/* The edited task, read back out of the workflow the footer committed. */
+const committedTask = (commitWorkflow: ReturnType<typeof vi.fn>) =>
+  nodeAt(commitWorkflow.mock.calls[0]![0] as Specification.Workflow, NODE_ID).data
+    .task as Record<string, unknown>;
+
+const editMethod = async (user: ReturnType<typeof userEvent.setup>, value: string) => {
+  await user.click(screen.getByText("patch"));
+  const input = screen.getByLabelText("with.method");
+  await user.clear(input);
+  await user.type(input, value);
+};
+
+describe("EditFormFooter", () => {
+  it("stays hidden before edit mode is entered", () => {
+    renderFooter();
+
+    expect(screen.queryByRole("button", { name: "Apply" })).not.toBeInTheDocument();
+  });
+
+  /* Cancel is the only way out of edit mode until the Edit button lands, so the footer has
+     to be present, and its exit usable, before anything has been changed. */
+  it("appears on entering edit mode, with a way out but nothing to apply", async () => {
+    const user = userEvent.setup();
+    renderFooter();
+
+    await user.click(screen.getByText("patch"));
+
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
+    expect(screen.getByText("No changes")).toBeInTheDocument();
+  });
+
+  it("enables applying, and counts the changed fields, once they change", async () => {
+    const user = userEvent.setup();
+    renderFooter();
+
+    await editMethod(user, "delete");
+
+    expect(screen.getByRole("button", { name: "Apply" })).toBeEnabled();
+    expect(screen.queryByText("No changes")).not.toBeInTheDocument();
+    expect(screen.getByText("1 changed")).toBeInTheDocument();
+
+    const endpoint = screen.getByLabelText("with.endpoint");
+    await user.clear(endpoint);
+    await user.type(endpoint, "https://api.github.com/other");
+
+    expect(screen.getByText("2 changed")).toBeInTheDocument();
+  });
+
+  it("stays hidden in read-only mode", async () => {
+    const user = userEvent.setup();
+    renderFooter({ isReadOnly: true });
+
+    expect(screen.queryByText("patch")).toBeInTheDocument();
+    await user.click(screen.getByText("patch"));
+
+    expect(screen.queryByRole("button", { name: "Apply" })).not.toBeInTheDocument();
+  });
+
+  describe("cancel", () => {
+    /* Interim: Cancel doubles as the way out of edit mode until the Edit
+       button lands. See the note in EditFormFooter. */
+    it("discards the draft, leaves edit mode, and takes the footer with it", async () => {
+      const user = userEvent.setup();
+      renderFooter();
+
+      await editMethod(user, "delete");
+      await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+      expect(screen.queryByLabelText("with.method")).not.toBeInTheDocument();
+      expect(screen.getByText("patch")).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Apply" })).not.toBeInTheDocument();
+    });
+  });
+
+  /* The count slot is the only feedback the footer gives: Apply otherwise just greys its own
+     button out. Each state is asserted by its wording, not its colour. */
+  describe("status message", () => {
+    /* Announced rather than shown only, since a keyboard user's focus stays on Apply. */
+    it("confirms the commit, announcing it politely", async () => {
+      const user = userEvent.setup();
+      renderFooter();
+
+      await editMethod(user, "delete");
+      await user.click(screen.getByRole("button", { name: "Apply" }));
+
+      expect(screen.getByRole("status")).toHaveTextContent("Applied");
+    });
+
+    it("gives way to the count as soon as editing resumes", async () => {
+      const user = userEvent.setup();
+      renderFooter();
+
+      await editMethod(user, "delete");
+      await user.click(screen.getByRole("button", { name: "Apply" }));
+      await user.type(screen.getByLabelText("with.method"), "X");
+
+      expect(screen.queryByText("Applied")).not.toBeInTheDocument();
+      expect(screen.getByText("1 changed")).toBeInTheDocument();
+    });
+
+    describe("expiry", () => {
+      beforeEach(() => {
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+      });
+
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      it("retires on its own, leaving the resting state", async () => {
+        const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+        renderFooter();
+
+        await editMethod(user, "delete");
+        await user.click(screen.getByRole("button", { name: "Apply" }));
+        expect(screen.getByText("Applied")).toBeInTheDocument();
+
+        await act(async () => {
+          vi.advanceTimersByTime(3000);
+        });
+
+        expect(screen.queryByText("Applied")).not.toBeInTheDocument();
+        expect(screen.getByText("No changes")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("apply", () => {
+    it("commits the edited value", async () => {
+      const user = userEvent.setup();
+      const { commitWorkflow } = renderFooter();
+
+      await editMethod(user, "delete");
+      await user.click(screen.getByRole("button", { name: "Apply" }));
+
+      expect(commitWorkflow).toHaveBeenCalledTimes(1);
+      expect(committedTask(commitWorkflow).with.method).toBe("delete");
+    });
+
+    /* Apply re-baselines the draft, so the panel stays in edit mode with a clean
+       footer rather than the footer vanishing under the user. */
+    it("leaves the panel in edit mode with nothing left to apply", async () => {
+      const user = userEvent.setup();
+      renderFooter();
+
+      await editMethod(user, "delete");
+      await user.click(screen.getByRole("button", { name: "Apply" }));
+
+      expect(screen.getByLabelText("with.method")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Apply" })).toBeDisabled();
+    });
+
+    /* The draft is merged onto the task rather than rebuilt from it: the rows are a lossy
+       view, so anything they never showed would otherwise be dropped on every Apply. */
+    it("carries over every field the change did not name", async () => {
+      const user = userEvent.setup();
+      const { commitWorkflow } = renderFooter();
+
+      await editMethod(user, "delete");
+      await user.click(screen.getByRole("button", { name: "Apply" }));
+
+      const committed = committedTask(commitWorkflow);
+      expect(committed.call).toBe("http");
+      expect(committed.with.endpoint).toBe(
+        "https://api.github.com/repos/{organization}/{repository}/issues/{issueNumber}",
+      );
+      expect(committed.with.body).toEqual({ state: "closed" });
+    });
+  });
+});
+
+describe("EditFormFooter on a node that is not an addressable task", () => {
+  const frameNode = {
+    id: "/do/tryTask/try",
+    type: "try",
+    position: { x: 0, y: 0 },
+    data: { label: "tryTask (try)", task: TRY_CATCH_TASK },
+  } as RF.Node<BaseNodeData>;
+
+  const renderFrame = () =>
+    renderWithProviders(
+      <>
+        <EditableProperties fields={getTaskDetails(TRY_CATCH_TASK as never)} nodeId={frameNode.id} />
+        <EditFormFooter node={frameNode} />
+      </>,
+      { isReadOnly: false, contentFormat: "yaml", model: {} as never, commitWorkflow: vi.fn() },
+    );
+
+  it("never offers the footer, even in edit mode", async () => {
+    const user = userEvent.setup();
+    renderFrame();
+
+    await user.click(screen.getByText("error"));
+
+    expect(screen.getByLabelText("catch.as")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Apply" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument();
+  });
+});

--- a/packages/open-workflow-diagram-editor/tests/side-panel/SidePanel.test.tsx
+++ b/packages/open-workflow-diagram-editor/tests/side-panel/SidePanel.test.tsx
@@ -16,6 +16,7 @@
 
 import { describe, it, expect } from "vitest";
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { SidePanel } from "../../src/side-panel/SidePanel";
 import { parseWorkflow } from "../../src/core/workflowSdk";
 import { renderWithProviders } from "../test-utils/render-helpers";
@@ -179,4 +180,51 @@ describe("SidePanel", () => {
 
     expect(screen.getByTestId("workflow-info")).toBeInTheDocument();
   });
+
+  describe("edit mode footer", () => {
+       /* The workflow's own task, so the node the panel is given matches what the write path
+      would resolve rather than describing a task the workflow does not contain. */
+   const selectedNode = {
+     id: "/do/step1",
+     type: "set",
+     position: { x: 0, y: 0 },
+     data: {
+       label: "step1",
+       task: { set: { variable: "my first workflow" } },
+       taskReference: "/do/0/step1",
+     },
+   };
+
+
+   const renderWithSelection = () => {
+     const { model } = parseWorkflow(WORKFLOW_WITH_METADATA_JSON);
+     return renderWithProviders(<SidePanel />, {
+       model,
+       isReadOnly: false,
+       nodes: [selectedNode],
+       selectedNodeId: selectedNode.id,
+     });
+   };
+
+
+   /* The panel body and the footer are siblings, so this is the wiring assertion: the draft
+      typed into a row is the one the pinned footer sees. When the footer itself decides to
+      show is covered in EditFormFooter's own tests. */
+   it("reaches the same draft the property rows write to", async () => {
+     const user = userEvent.setup();
+     renderWithSelection();
+
+
+     expect(screen.queryByRole("button", { name: "Apply" })).not.toBeInTheDocument();
+
+
+     await user.click(screen.getByText("my first workflow"));
+     await user.type(screen.getByLabelText("set.variable"), "X");
+
+
+     expect(screen.getByRole("button", { name: "Apply" })).toBeEnabled();
+     expect(screen.getByText("1 changed")).toBeInTheDocument();
+   });
+ });
+
 });

--- a/packages/open-workflow-diagram-editor/tests/store/DiagramEditorContextProvider.test.tsx
+++ b/packages/open-workflow-diagram-editor/tests/store/DiagramEditorContextProvider.test.tsx
@@ -356,3 +356,54 @@ describe("DiagramEditorContextProvider Component", () => {
     });
   });
 });
+
+
+
+  describe("commitWorkflow", () => {
+    const CommitWorkflowButton: React.FC = () => {
+      const { commitWorkflow, model, errors } = useDiagramEditorContext();
+
+      const handleCommit = () => {
+        if (!model) return;
+        
+        // Modify the workflow - change the document name
+        const updated = {
+          ...model,
+          document: { ...model.document, name: "updated-workflow" },
+        };
+        commitWorkflow(updated);
+      };
+
+      return (
+        <div>
+          <button data-testid="commit-button" onClick={handleCommit}>
+            Commit
+          </button>
+          <p data-testid="workflow-name">{model?.document?.name ?? "null"}</p>
+          <p data-testid="error-count">{errors.length}</p>
+        </div>
+      );
+    };
+
+    it("updates the model when a valid workflow is committed", async () => {
+      render(
+        <DiagramEditorContextProvider
+          content={BASIC_VALID_WORKFLOW_YAML}
+          isReadOnly={false}
+          locale="en"
+        >
+          <CommitWorkflowButton />
+        </DiagramEditorContextProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("workflow-name")).toHaveTextContent("valid-workflow-yaml");
+      });
+
+      fireEvent.click(screen.getByTestId("commit-button"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("workflow-name")).toHaveTextContent("updated-workflow");
+      });
+    });
+  });

--- a/packages/open-workflow-diagram-editor/tests/test-utils/index.ts
+++ b/packages/open-workflow-diagram-editor/tests/test-utils/index.ts
@@ -17,3 +17,4 @@
 export { renderWithProviders } from "./render-helpers";
 export { t } from "./translation-helpers";
 export { createFlatGraph } from "./graph-helpers";
+export {nodeAt, parseFixture} from "./workflow-helpers";

--- a/packages/open-workflow-diagram-editor/tests/test-utils/render-helpers.tsx
+++ b/packages/open-workflow-diagram-editor/tests/test-utils/render-helpers.tsx
@@ -22,6 +22,7 @@ import {
 } from "../../src/store/DiagramEditorContext";
 import { SidebarProvider } from "../../src/components/ui/sidebar";
 import { en } from "../../src/i18n/locales/en";
+import { EditSessionProvider } from "../../src/side-panel/EditSession";
 
 const noop = () => {};
 
@@ -49,6 +50,7 @@ export const createMockContextValue = (
   setNodes: noop,
   setSelectedNodeId: noop,
   setContent: noop,
+  commitWorkflow: noop,
 
   // --- history defaults ---
   submitModel: noop,
@@ -76,7 +78,8 @@ export const renderWithProviders = (
   const Providers = ({ children }: { children: React.ReactNode }) => (
     <DiagramEditorContext.Provider value={mockContext}>
       <I18nProvider locale={mockContext.locale} dictionaries={{ en }}>
-        <SidebarProvider defaultOpen={true}>{children}</SidebarProvider>
+        <SidebarProvider defaultOpen={true}>
+          <EditSessionProvider>{children}</EditSessionProvider></SidebarProvider>
       </I18nProvider>
     </DiagramEditorContext.Provider>
   );

--- a/packages/open-workflow-diagram-editor/tests/test-utils/workflow-helpers.ts
+++ b/packages/open-workflow-diagram-editor/tests/test-utils/workflow-helpers.ts
@@ -1,0 +1,77 @@
+/*
+* Copyright 2021-Present The Open Workflow Specification Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+
+import type * as RF from "@xyflow/react";
+import type { Specification } from "@openworkflowspec/sdk";
+import { parseWorkflow } from "../../src/core";
+import { buildDiagramElements } from "../../src/react-flow/diagram/diagramBuilder";
+import type { BaseNodeData } from "../../src/react-flow/nodes/Nodes";
+
+
+/**
+* Parses a fixture that is expected to be valid, narrowing away the `null` model.
+*
+* `parseWorkflow` returns `model: Workflow | null` because it must survive unparseable
+* input, but a fixture under test is not that case. Throwing here rather than asserting
+* non-null at each use means a fixture broken by an edit fails with a message naming the
+* problem, instead of a null dereference somewhere downstream.
+*
+* @param workflow - Fixture source: a workflow object, or YAML/JSON text.
+* @returns The parsed workflow model.
+*/
+export function parseFixture(workflow: object | string): Specification.Workflow {
+ const text = typeof workflow === "string" ? workflow : JSON.stringify(workflow);
+ const { model } = parseWorkflow(text);
+
+
+ if (model === null) {
+   throw new Error("Fixture failed to parse");
+ }
+
+
+ return model;
+}
+
+
+/**
+* The React Flow node the diagram builder produces for a task.
+*
+* Tests that need a node should take it from here rather than hand-writing one: the id,
+* `taskReference` and task then match what the editor actually renders, so a test cannot
+* assert against a node shape the builder never produces.
+*
+* @param workflow - The workflow to build the diagram from.
+* @param id - The node id, e.g. `/do/tryTask/try`.
+* @returns The matching node.
+*/
+export function nodeAt(
+ workflow: Specification.Workflow,
+ id: string,
+): RF.Node<BaseNodeData> {
+ const node = buildDiagramElements(workflow).nodes.find((candidate) => candidate.id === id);
+
+
+ if (node === undefined) {
+   throw new Error(`No node with id ${id}`);
+ }
+
+
+ return node as RF.Node<BaseNodeData>;
+}
+
+
+


### PR DESCRIPTION
### Summary

Closes: https://github.com/open-workflow-specification/editor/issues/296

Adds a footer to the side panel for editing that enables users to apply or cancel changes when editing task properties inline. Part of this work will overlap with validation logic so taskDraft will eventually be removed as the rendering of fields will come from the schema and a chunk of the form once we generate fields from the schema. We are implementing bit by bit so some refactoring is inevitable as we are developing

**Not addressed in this PR**

Undo/redo is an API, not editor chrome - undo, redo, canUndo, canRedo live on DiagramEditorRef because the host owns the toolbar. The toolbar in UndoRedo.stories.tsx is story scaffolding, not a component we ship.

That works while the host drives every change. It breaks for editor-originated ones, which this PR introduces:

1. User edits a node in the side panel and hits Apply.
2. commitWorkflow pushes a history entry - canUndo flips false → true.
3. The host is never told, so it never re-renders, so it never re-reads ref.current.canUndo.
4. Its undo button stays disabled even though there's something to undo.

This will be fixed in a subsequent PR when we implement an `onChange?: (content: string) => void;`


https://github.com/user-attachments/assets/eb9c40fc-6652-4214-ba4a-15ce7d2c10c1

