### PR TITLE
feat: Deploy latest release to github pages

### DIFF
--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -1,0 +1,218 @@
+#
+# Copyright 2021-Present The Open Workflow Specification Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: "Release :: Deploy to GitHub Pages"
+
+# Publishes the Storybook of a RELEASED version to GitHub Pages.
+#
+# Always built from the exact git tag, never from `main`, so the deployed site
+# shows only what is on npm. Unreleased work on `main` keeps its Netlify
+# preview (see netlify.toml) and never reaches Pages.
+#
+# Each release lands in its own permanent directory (/1.0.0/, /1.1.0/, ...);
+# `latest/` is a copy of the highest stable release. Nothing is ever deleted.
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git tag to build and deploy."
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git tag to build and deploy (e.g. @openworkflowspec/diagram-editor@1.1.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+# Serialise deploys so two releases cannot race on the same branch.
+concurrency:
+  group: deploy-pages
+  cancel-in-progress: false
+
+env:
+  EDITOR_PACKAGE_NAME: "@openworkflowspec/diagram-editor"
+  EDITOR_PACKAGE_DIR: "packages/open-workflow-diagram-editor"
+  PAGES_BRANCH: "gh-pages"
+  # The released source is checked out here, kept apart from the deploy tooling
+  # at the workspace root. They are different vintages on purpose: the tooling
+  # must be this workflow's version, the source must be the tag's.
+  RELEASE_DIR: "release"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      # This workflow's own ref, for the deploy tooling. Deploying an old tag
+      # must not mean running that tag's CI actions.
+      - name: Checkout deploy tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Checkout released tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref }}
+          path: ${{ env.RELEASE_DIR }}
+
+      # Only an immutable tag may be deployed -- that is the point of the job.
+      - name: Verify the ref is a tag
+        working-directory: ${{ env.RELEASE_DIR }}
+        run: |
+          set -euo pipefail
+          if ! git describe --exact-match --tags HEAD >/dev/null 2>&1; then
+            echo "::error::'${{ inputs.ref }}' is not a git tag. Only released tags may be deployed."
+            exit 1
+          fi
+          echo "Deploying tag: $(git describe --exact-match --tags HEAD)"
+
+      - name: Setup CI
+        uses: ./.github/actions/setup-ci
+
+      - name: Read released version
+        id: version
+        run: |
+          set -euo pipefail
+          VERSION="$(node -p "require('./${RELEASE_DIR}/${EDITOR_PACKAGE_DIR}/package.json').version")"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          # A prerelease must never become `latest`.
+          case "$VERSION" in
+            *-*) echo "stable=false" >> "$GITHUB_OUTPUT" ;;
+            *)   echo "stable=true"  >> "$GITHUB_OUTPUT" ;;
+          esac
+          echo "Version: ${VERSION}"
+
+      - name: Install dependencies
+        working-directory: ${{ env.RELEASE_DIR }}
+        run: pnpm install --frozen-lockfile
+
+      - name: Build editor and Storybook
+        working-directory: ${{ env.RELEASE_DIR }}
+        run: |
+          set -euo pipefail
+          pnpm -F "${EDITOR_PACKAGE_NAME}..." build:dev
+          pnpm -F "${EDITOR_PACKAGE_NAME}" build:storybook
+
+      # Done by hand rather than with actions/checkout because the branch does
+      # not exist on the first run and has to be created as an orphan.
+      - name: Checkout gh-pages branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/pages"
+          cd "${RUNNER_TEMP}/pages"
+          git init -q
+          git remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          if git fetch -q --depth=1 origin "${PAGES_BRANCH}" 2>/dev/null; then
+            git checkout -q FETCH_HEAD
+            git checkout -q -B "${PAGES_BRANCH}"
+            echo "Existing ${PAGES_BRANCH} checked out."
+          else
+            git checkout -q --orphan "${PAGES_BRANCH}"
+            echo "No ${PAGES_BRANCH} yet -- creating it."
+          fi
+
+      - name: Stage this release
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          STABLE: ${{ steps.version.outputs.stable }}
+        run: |
+          set -euo pipefail
+          PAGES="${RUNNER_TEMP}/pages"
+          BUILD="${GITHUB_WORKSPACE}/${RELEASE_DIR}/${EDITOR_PACKAGE_DIR}/dist-storybook"
+
+          # Redeploying a tag must be idempotent, so the version directory is
+          # replaced wholesale rather than merged into.
+          rm -rf "${PAGES:?}/${VERSION:?}"
+          mkdir -p "${PAGES}/${VERSION}"
+          cp -R "${BUILD}/." "${PAGES}/${VERSION}/"
+
+          # `latest` only ever moves forward. A patch released from a 1.0.x
+          # maintenance branch must not clobber a newer `latest`.
+          if [ "${STABLE}" = "true" ]; then
+            HIGHEST="$(
+              cd "${PAGES}" && for d in */; do echo "${d%/}"; done \
+                | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+                | sort -V | tail -1
+            )"
+            if [ "${HIGHEST}" = "${VERSION}" ]; then
+              rm -rf "${PAGES}/latest"
+              cp -R "${PAGES}/${VERSION}" "${PAGES}/latest"
+              echo "latest -> ${VERSION}"
+            else
+              echo "Keeping latest at ${HIGHEST} (${VERSION} is older)."
+            fi
+          else
+            echo "${VERSION} is a prerelease -- latest untouched."
+          fi
+
+          # Send the site root to the current release. A browsable index of all
+          # versions is deliberately left to a follow-up.
+          cat > "${PAGES}/index.html" <<'HTML'
+          <!doctype html>
+          <meta charset="utf-8" />
+          <title>Open Workflow Editor</title>
+          <meta http-equiv="refresh" content="0; url=./latest/" />
+          <a href="./latest/">Open the latest release</a>
+          HTML
+
+          # Serve the directory as-is instead of running it through Jekyll,
+          # which would drop any path segment starting with "_".
+          touch "${PAGES}/.nojekyll"
+
+      - name: Publish to gh-pages
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          cd "${RUNNER_TEMP}/pages"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Nothing changed -- ${VERSION} is already deployed."
+            exit 0
+          fi
+          git -c user.name="github-actions[bot]" \
+              -c user.email="github-actions[bot]@users.noreply.github.com" \
+              commit -q -m "deploy: ${EDITOR_PACKAGE_NAME}@${VERSION} to GitHub Pages
+
+          Signed-off-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+          git push -q origin "${PAGES_BRANCH}"
+          echo "Pushed ${VERSION} to ${PAGES_BRANCH}."
+
+      - name: Summary
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Derived, not hardcoded, so a fork reports its own Pages URL.
+          OWNER="$(echo "${GITHUB_REPOSITORY%%/*}" | tr '[:upper:]' '[:lower:]')"
+          REPO="${GITHUB_REPOSITORY#*/}"
+          BASE="https://${OWNER}.github.io/${REPO}"
+          {
+            echo "### Deployed to GitHub Pages"
+            echo
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Tag | \`${{ inputs.ref }}\` |"
+            echo "| Version | \`${VERSION}\` |"
+            echo "| This version | ${BASE}/${VERSION}/ |"
+            echo "| Site root | ${BASE}/ |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -75,7 +75,9 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build Storybook
         working-directory: release
-        run: pnpm -F "${DEPLOY_PREVIEW_PACKAGE_NAME}" build:storybook
+        run: |
+          pnpm -F "${DEPLOY_PREVIEW_PACKAGE_NAME}..." build:dev
+          pnpm -F "${DEPLOY_PREVIEW_PACKAGE_NAME}" build:storybook
       - name: Checkout gh-pages
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -75,13 +75,30 @@ jobs:
       # Only an immutable tag may be deployed -- that is the point of the job.
       - name: Verify the ref is a tag
         working-directory: ${{ env.RELEASE_DIR }}
+        env:
+          # Via env rather than inline `${{ }}` so the value cannot be
+          # interpreted as shell.
+          REF: ${{ inputs.ref }}
         run: |
           set -euo pipefail
-          if ! git describe --exact-match --tags HEAD >/dev/null 2>&1; then
-            echo "::error::'${{ inputs.ref }}' is not a git tag. Only released tags may be deployed."
+          # Check that the INPUT names a tag, not merely that HEAD happens to
+          # carry one: right after a release, main's tip IS the tagged commit,
+          # so a HEAD-based check would silently accept a branch.
+          #
+          # `show-ref --verify` takes a literal ref path and does NOT interpret
+          # revision expressions, so `<tag>~1` cannot slip through as a commit
+          # reachable from a real tag. Only once the literal tag is known to
+          # exist is it safe to dereference it.
+          if ! git show-ref --verify --quiet "refs/tags/${REF}"; then
+            echo "::error::'${REF}' is not a git tag. Only released tags may be deployed."
             exit 1
           fi
-          echo "Deploying tag: $(git describe --exact-match --tags HEAD)"
+          if [ "$(git rev-parse --verify HEAD)" \
+             != "$(git rev-parse --verify "refs/tags/${REF}^{commit}")" ]; then
+            echo "::error::HEAD does not match tag '${REF}'."
+            exit 1
+          fi
+          echo "Deploying tag: ${REF}"
 
       - name: Setup CI
         uses: ./.github/actions/setup-ci
@@ -131,6 +148,7 @@ jobs:
           fi
 
       - name: Stage this release
+        id: stage
         env:
           VERSION: ${{ steps.version.outputs.version }}
           STABLE: ${{ steps.version.outputs.stable }}
@@ -146,32 +164,53 @@ jobs:
           cp -R "${BUILD}/." "${PAGES}/${VERSION}/"
 
           # `latest` only ever moves forward. A patch released from a 1.0.x
-          # maintenance branch must not clobber a newer `latest`.
-          if [ "${STABLE}" = "true" ]; then
-            HIGHEST="$(
-              cd "${PAGES}" && for d in */; do echo "${d%/}"; done \
-                | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
-                | sort -V | tail -1
-            )"
-            if [ "${HIGHEST}" = "${VERSION}" ]; then
-              rm -rf "${PAGES}/latest"
-              cp -R "${PAGES}/${VERSION}" "${PAGES}/latest"
-              echo "latest -> ${VERSION}"
-            else
-              echo "Keeping latest at ${HIGHEST} (${VERSION} is older)."
-            fi
-          else
+          # maintenance branch must not clobber a newer `latest`. Only stable
+          # version directories are candidates, so a prerelease never wins.
+          # `|| true` because grep exits 1 when no stable release exists yet
+          # (e.g. a prerelease is the first thing ever deployed), and under
+          # `pipefail` that would abort the step.
+          HIGHEST="$(
+            cd "${PAGES}" && for d in */; do echo "${d%/}"; done \
+              | { grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true; } \
+              | sort -V | tail -1
+          )"
+          if [ "${STABLE}" != "true" ]; then
             echo "${VERSION} is a prerelease -- latest untouched."
+            # `none` rather than "" so the summary cannot render "still ``".
+            LATEST_STATE="prerelease"; LATEST_VERSION="${HIGHEST:-none}"
+          elif [ "${HIGHEST}" = "${VERSION}" ]; then
+            rm -rf "${PAGES}/latest"
+            cp -R "${PAGES}/${VERSION}" "${PAGES}/latest"
+            echo "latest -> ${VERSION}"
+            LATEST_STATE="moved"; LATEST_VERSION="${VERSION}"
+          else
+            echo "Keeping latest at ${HIGHEST} (${VERSION} is older)."
+            LATEST_STATE="kept"; LATEST_VERSION="${HIGHEST}"
           fi
+          # Surfaced in the job summary: on a maintenance or prerelease deploy
+          # "latest did not move" is the most important outcome of the run, and
+          # must not require reading the step log to discover.
+          echo "latest_state=${LATEST_STATE}" >> "$GITHUB_OUTPUT"
+          echo "latest_version=${LATEST_VERSION}" >> "$GITHUB_OUTPUT"
 
-          # Send the site root to the current release. A browsable index of all
-          # versions is deliberately left to a follow-up.
-          cat > "${PAGES}/index.html" <<'HTML'
+          # Send the site root to `latest`, falling back to the version just
+          # deployed when no stable release exists yet -- otherwise the root
+          # would redirect to a 404. A browsable index of all versions is
+          # deliberately left to a follow-up.
+          # The link text names what the root actually points at: "the latest
+          # release" is false in the fallback case, and the anchor is what a
+          # reader sees if the meta refresh is blocked.
+          if [ -d "${PAGES}/latest" ]; then
+            ROOT_TARGET="latest"; ROOT_LABEL="Open the latest release"
+          else
+            ROOT_TARGET="${VERSION}"; ROOT_LABEL="Open ${VERSION}"
+          fi
+          cat > "${PAGES}/index.html" <<HTML
           <!doctype html>
           <meta charset="utf-8" />
           <title>Open Workflow Editor</title>
-          <meta http-equiv="refresh" content="0; url=./latest/" />
-          <a href="./latest/">Open the latest release</a>
+          <meta http-equiv="refresh" content="0; url=./${ROOT_TARGET}/" />
+          <a href="./${ROOT_TARGET}/">${ROOT_LABEL}</a>
           HTML
 
           # Serve the directory as-is instead of running it through Jekyll,
@@ -199,20 +238,35 @@ jobs:
 
       - name: Summary
         env:
+          REF: ${{ inputs.ref }}
           VERSION: ${{ steps.version.outputs.version }}
+          LATEST_STATE: ${{ steps.stage.outputs.latest_state }}
+          LATEST_VERSION: ${{ steps.stage.outputs.latest_version }}
         run: |
           set -euo pipefail
           # Derived, not hardcoded, so a fork reports its own Pages URL.
           OWNER="$(echo "${GITHUB_REPOSITORY%%/*}" | tr '[:upper:]' '[:lower:]')"
           REPO="${GITHUB_REPOSITORY#*/}"
           BASE="https://${OWNER}.github.io/${REPO}"
+
+          if [ "${LATEST_VERSION}" = "none" ]; then
+            LATEST_CELL="**not created** -- no stable release has been deployed yet"
+          else
+            case "${LATEST_STATE}" in
+              moved) LATEST_CELL="updated to \`${LATEST_VERSION}\`" ;;
+              kept)  LATEST_CELL="**unchanged** -- still \`${LATEST_VERSION}\`, which is newer than this release" ;;
+              *)     LATEST_CELL="**unchanged** -- still \`${LATEST_VERSION}\` (this is a prerelease)" ;;
+            esac
+          fi
+
           {
             echo "### Deployed to GitHub Pages"
             echo
-            echo "| | |"
-            echo "|---|---|"
-            echo "| Tag | \`${{ inputs.ref }}\` |"
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Tag | \`${REF}\` |"
             echo "| Version | \`${VERSION}\` |"
+            echo "| \`latest\` | ${LATEST_CELL} |"
             echo "| This version | ${BASE}/${VERSION}/ |"
             echo "| Site root | ${BASE}/ |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -15,258 +15,95 @@
 #
 
 name: "Release :: Deploy to GitHub Pages"
-
-# Publishes the Storybook of a RELEASED version to GitHub Pages.
-#
-# Always built from the exact git tag, never from `main`, so the deployed site
-# shows only what is on npm. Unreleased work on `main` keeps its Netlify
-# preview (see netlify.toml) and never reaches Pages.
-#
-# Each release lands in its own permanent directory (/1.0.0/, /1.1.0/, ...);
-# `latest/` is a copy of the highest stable release. Nothing is ever deleted.
-
 on:
   workflow_call:
     inputs:
-      ref:
-        description: "Git tag to build and deploy."
+      version:
         required: true
         type: string
+      latest:
+        description: "Set this version as latest"
+        required: false
+        type: boolean
+        default: true
+      dry_run:
+        description: "Run without pushing or deploying"
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
-      ref:
-        description: "Git tag to build and deploy (e.g. @openworkflowspec/diagram-editor@1.1.0)"
+      version:
+        description: "Release version, e.g. 1.1.0"
         required: true
         type: string
-
-permissions:
-  contents: write
-
-# Serialise deploys so two releases cannot race on the same branch.
+      latest:
+        description: "Set this version as latest"
+        required: false
+        type: boolean
+        default: true
+      dry_run:
+        description: "Run without pushing or deploying"
+        type: boolean
+        default: false
 concurrency:
   group: deploy-pages
   cancel-in-progress: false
-
 env:
-  EDITOR_PACKAGE_NAME: "@openworkflowspec/diagram-editor"
-  EDITOR_PACKAGE_DIR: "packages/open-workflow-diagram-editor"
-  PAGES_BRANCH: "gh-pages"
-  # The released source is checked out here, kept apart from the deploy tooling
-  # at the workspace root. They are different vintages on purpose: the tooling
-  # must be this workflow's version, the source must be the tag's.
-  RELEASE_DIR: "release"
-
+  DEPLOY_PREVIEW_PACKAGE_NAME: ${{ vars.PREVIEW_PACKAGE_NAME }}
+  DEPLOY_PREVIEW_PACKAGE_DIR: ${{ vars.PREVIEW_PACKAGE_DIR }}
+  DEPLOY_PREVIEW_PACKAGE_TAG: ${{ vars.PREVIEW_PACKAGE_NAME }}@${{ inputs.version }}
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      # This workflow's own ref, for the deploy tooling. Deploying an old tag
-      # must not mean running that tag's CI actions.
-      - name: Checkout deploy tooling
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Checkout released tag
+      - name: Checkout release
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.ref }}
-          path: ${{ env.RELEASE_DIR }}
-
-      # Only an immutable tag may be deployed -- that is the point of the job.
-      - name: Verify the ref is a tag
-        working-directory: ${{ env.RELEASE_DIR }}
-        env:
-          # Via env rather than inline `${{ }}` so the value cannot be
-          # interpreted as shell.
-          REF: ${{ inputs.ref }}
-        run: |
-          set -euo pipefail
-          # Check that the INPUT names a tag, not merely that HEAD happens to
-          # carry one: right after a release, main's tip IS the tagged commit,
-          # so a HEAD-based check would silently accept a branch.
-          #
-          # `show-ref --verify` takes a literal ref path and does NOT interpret
-          # revision expressions, so `<tag>~1` cannot slip through as a commit
-          # reachable from a real tag. Only once the literal tag is known to
-          # exist is it safe to dereference it.
-          if ! git show-ref --verify --quiet "refs/tags/${REF}"; then
-            echo "::error::'${REF}' is not a git tag. Only released tags may be deployed."
-            exit 1
-          fi
-          if [ "$(git rev-parse --verify HEAD)" \
-             != "$(git rev-parse --verify "refs/tags/${REF}^{commit}")" ]; then
-            echo "::error::HEAD does not match tag '${REF}'."
-            exit 1
-          fi
-          echo "Deploying tag: ${REF}"
-
+          ref: ${{ env.DEPLOY_PREVIEW_PACKAGE_TAG }}
+          path: release
       - name: Setup CI
-        uses: ./.github/actions/setup-ci
-
-      - name: Read released version
-        id: version
-        run: |
-          set -euo pipefail
-          VERSION="$(node -p "require('./${RELEASE_DIR}/${EDITOR_PACKAGE_DIR}/package.json').version")"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          # A prerelease must never become `latest`.
-          case "$VERSION" in
-            *-*) echo "stable=false" >> "$GITHUB_OUTPUT" ;;
-            *)   echo "stable=true"  >> "$GITHUB_OUTPUT" ;;
-          esac
-          echo "Version: ${VERSION}"
-
+        uses: ./release/.github/actions/setup-ci
       - name: Install dependencies
-        working-directory: ${{ env.RELEASE_DIR }}
+        working-directory: release
         run: pnpm install --frozen-lockfile
-
-      - name: Build editor and Storybook
-        working-directory: ${{ env.RELEASE_DIR }}
+      - name: Build Storybook
+        working-directory: release
+        run: pnpm -F "${DEPLOY_PREVIEW_PACKAGE_NAME}" build:storybook
+      - name: Checkout gh-pages
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: gh-pages
+          path: pages
+      - name: Add release
         run: |
-          set -euo pipefail
-          pnpm -F "${EDITOR_PACKAGE_NAME}..." build:dev
-          pnpm -F "${EDITOR_PACKAGE_NAME}" build:storybook
-
-      # Done by hand rather than with actions/checkout because the branch does
-      # not exist on the first run and has to be created as an orphan.
-      - name: Checkout gh-pages branch
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          mkdir -p "${RUNNER_TEMP}/pages"
-          cd "${RUNNER_TEMP}/pages"
-          git init -q
-          git remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          if git fetch -q --depth=1 origin "${PAGES_BRANCH}" 2>/dev/null; then
-            git checkout -q FETCH_HEAD
-            git checkout -q -B "${PAGES_BRANCH}"
-            echo "Existing ${PAGES_BRANCH} checked out."
-          else
-            git checkout -q --orphan "${PAGES_BRANCH}"
-            echo "No ${PAGES_BRANCH} yet -- creating it."
+          BUILD="release/${DEPLOY_PREVIEW_PACKAGE_DIR}/dist-storybook"
+          rm -rf "pages/${{ inputs.version }}"
+          cp -R "${BUILD}" "pages/${{ inputs.version }}"
+          if [ "${{ inputs.latest }}" = "true" ]; then
+            rm -rf pages/latest
+            ln -s "${{ inputs.version }}" pages/latest
           fi
-
-      - name: Stage this release
-        id: stage
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-          STABLE: ${{ steps.version.outputs.stable }}
+      - name: Update gh-pages
         run: |
-          set -euo pipefail
-          PAGES="${RUNNER_TEMP}/pages"
-          BUILD="${GITHUB_WORKSPACE}/${RELEASE_DIR}/${EDITOR_PACKAGE_DIR}/dist-storybook"
-
-          # Redeploying a tag must be idempotent, so the version directory is
-          # replaced wholesale rather than merged into.
-          rm -rf "${PAGES:?}/${VERSION:?}"
-          mkdir -p "${PAGES}/${VERSION}"
-          cp -R "${BUILD}/." "${PAGES}/${VERSION}/"
-
-          # `latest` only ever moves forward. A patch released from a 1.0.x
-          # maintenance branch must not clobber a newer `latest`. Only stable
-          # version directories are candidates, so a prerelease never wins.
-          # `|| true` because grep exits 1 when no stable release exists yet
-          # (e.g. a prerelease is the first thing ever deployed), and under
-          # `pipefail` that would abort the step.
-          HIGHEST="$(
-            cd "${PAGES}" && for d in */; do echo "${d%/}"; done \
-              | { grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true; } \
-              | sort -V | tail -1
-          )"
-          if [ "${STABLE}" != "true" ]; then
-            echo "${VERSION} is a prerelease -- latest untouched."
-            # `none` rather than "" so the summary cannot render "still ``".
-            LATEST_STATE="prerelease"; LATEST_VERSION="${HIGHEST:-none}"
-          elif [ "${HIGHEST}" = "${VERSION}" ]; then
-            rm -rf "${PAGES}/latest"
-            cp -R "${PAGES}/${VERSION}" "${PAGES}/latest"
-            echo "latest -> ${VERSION}"
-            LATEST_STATE="moved"; LATEST_VERSION="${VERSION}"
-          else
-            echo "Keeping latest at ${HIGHEST} (${VERSION} is older)."
-            LATEST_STATE="kept"; LATEST_VERSION="${HIGHEST}"
-          fi
-          # Surfaced in the job summary: on a maintenance or prerelease deploy
-          # "latest did not move" is the most important outcome of the run, and
-          # must not require reading the step log to discover.
-          echo "latest_state=${LATEST_STATE}" >> "$GITHUB_OUTPUT"
-          echo "latest_version=${LATEST_VERSION}" >> "$GITHUB_OUTPUT"
-
-          # Send the site root to `latest`, falling back to the version just
-          # deployed when no stable release exists yet -- otherwise the root
-          # would redirect to a 404. A browsable index of all versions is
-          # deliberately left to a follow-up.
-          # The link text names what the root actually points at: "the latest
-          # release" is false in the fallback case, and the anchor is what a
-          # reader sees if the meta refresh is blocked.
-          if [ -d "${PAGES}/latest" ]; then
-            ROOT_TARGET="latest"; ROOT_LABEL="Open the latest release"
-          else
-            ROOT_TARGET="${VERSION}"; ROOT_LABEL="Open ${VERSION}"
-          fi
-          cat > "${PAGES}/index.html" <<HTML
-          <!doctype html>
-          <meta charset="utf-8" />
-          <title>Open Workflow Editor</title>
-          <meta http-equiv="refresh" content="0; url=./${ROOT_TARGET}/" />
-          <a href="./${ROOT_TARGET}/">${ROOT_LABEL}</a>
-          HTML
-
-          # Serve the directory as-is instead of running it through Jekyll,
-          # which would drop any path segment starting with "_".
-          touch "${PAGES}/.nojekyll"
-
-      - name: Publish to gh-pages
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          set -euo pipefail
-          cd "${RUNNER_TEMP}/pages"
+          cd pages
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A
-          if git diff --cached --quiet; then
-            echo "Nothing changed -- ${VERSION} is already deployed."
-            exit 0
-          fi
-          git -c user.name="github-actions[bot]" \
-              -c user.email="github-actions[bot]@users.noreply.github.com" \
-              commit -q -m "deploy: ${EDITOR_PACKAGE_NAME}@${VERSION} to GitHub Pages
-
-          Signed-off-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
-          git push -q origin "${PAGES_BRANCH}"
-          echo "Pushed ${VERSION} to ${PAGES_BRANCH}."
-
-      - name: Summary
-        env:
-          REF: ${{ inputs.ref }}
-          VERSION: ${{ steps.version.outputs.version }}
-          LATEST_STATE: ${{ steps.stage.outputs.latest_state }}
-          LATEST_VERSION: ${{ steps.stage.outputs.latest_version }}
-        run: |
-          set -euo pipefail
-          # Derived, not hardcoded, so a fork reports its own Pages URL.
-          OWNER="$(echo "${GITHUB_REPOSITORY%%/*}" | tr '[:upper:]' '[:lower:]')"
-          REPO="${GITHUB_REPOSITORY#*/}"
-          BASE="https://${OWNER}.github.io/${REPO}"
-
-          if [ "${LATEST_VERSION}" = "none" ]; then
-            LATEST_CELL="**not created** -- no stable release has been deployed yet"
-          else
-            case "${LATEST_STATE}" in
-              moved) LATEST_CELL="updated to \`${LATEST_VERSION}\`" ;;
-              kept)  LATEST_CELL="**unchanged** -- still \`${LATEST_VERSION}\`, which is newer than this release" ;;
-              *)     LATEST_CELL="**unchanged** -- still \`${LATEST_VERSION}\` (this is a prerelease)" ;;
-            esac
-          fi
-
-          {
-            echo "### Deployed to GitHub Pages"
-            echo
-            echo "| Field | Value |"
-            echo "| --- | --- |"
-            echo "| Tag | \`${REF}\` |"
-            echo "| Version | \`${VERSION}\` |"
-            echo "| \`latest\` | ${LATEST_CELL} |"
-            echo "| This version | ${BASE}/${VERSION}/ |"
-            echo "| Site root | ${BASE}/ |"
-          } >> "$GITHUB_STEP_SUMMARY"
+          git commit -s -m "deploy: ${DEPLOY_PREVIEW_PACKAGE_NAME}@${{ inputs.version }}"
+          git push ${{ inputs.dry_run && '--dry-run' || '' }}
+      - name: Upload Pages artifact
+        if: ${{ !inputs.dry_run }}
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        with:
+          path: pages
+      - name: Deploy
+        id: deployment
+        if: ${{ !inputs.dry_run }}
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -37,6 +37,9 @@ jobs:
       github.event.pull_request.title == 'chore: version packages' &&
       startsWith(github.event.pull_request.head.ref, 'changeset-release/')
     runs-on: ubuntu-latest
+    outputs:
+      published: ${{ steps.publish.outputs.published }}
+      tag: ${{ steps.released-tag.outputs.tag }}
     steps:
       - name: Checkout release branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -56,6 +59,30 @@ jobs:
         run: pnpm build:prod
 
       - name: Publish to npm
+        id: publish
         uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
         with:
           publish: pnpm changeset publish
+
+      # changeset publish tags the commit it just published. Reconstruct that
+      # tag name so the Pages deploy builds from it rather than from the
+      # branch, which is free to move on afterwards.
+      - name: Resolve released tag
+        id: released-tag
+        if: steps.publish.outputs.published == 'true'
+        run: |
+          set -euo pipefail
+          VERSION="$(node -p "require('./packages/open-workflow-diagram-editor/package.json').version")"
+          echo "tag=@openworkflowspec/diagram-editor@${VERSION}" >> "$GITHUB_OUTPUT"
+
+  # Publishes the released Storybook to GitHub Pages. Gated on `published` so
+  # Pages only moves when npm does -- a re-run that publishes nothing
+  # redeploys nothing.
+  deploy-pages:
+    needs: publish
+    if: needs.publish.outputs.published == 'true'
+    uses: ./.github/workflows/deploy-pages.yaml
+    permissions:
+      contents: write
+    with:
+      ref: ${{ needs.publish.outputs.tag }}

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -72,8 +72,8 @@ jobs:
         if: steps.publish.outputs.published == 'true'
         run: |
           set -euo pipefail
-          VERSION="$(node -p "require('./packages/open-workflow-diagram-editor/package.json').version")"
-          echo "tag=@openworkflowspec/diagram-editor@${VERSION}" >> "$GITHUB_OUTPUT"
+          VERSION="$(node -p "require('./${{ vars.PREVIEW_PACKAGE_DIR }}/package.json').version")"
+          echo "tag={{ vars.PREVIEW_PACKAGE_NAME }}@${VERSION}" >> "$GITHUB_OUTPUT"
 
   # Publishes the released Storybook to GitHub Pages. Gated on `published` so
   # Pages only moves when npm does -- a re-run that publishes nothing

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The official **vendor-neutral visual editor** for the [Open Workflow Specificati
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![CNCF Sandbox](https://img.shields.io/badge/CNCF-Sandbox-informational)](https://www.cncf.io/projects/serverless-workflow/)
 
+**[Try the editor](https://open-workflow-specification.github.io/editor/latest/)** — the latest released version.
+
 ## Overview
 
 This project provides an interactive, visual diagram editor designed to be:
@@ -199,6 +201,7 @@ The `commit-msg` hook will automatically verify DCO compliance.
 
 - **Automated Testing**: All PRs run linting, type checking, unit tests, and E2E tests
 - **Netlify Previews**: Storybook is automatically deployed for PRs modifying the diagram editor package
+- **GitHub Pages**: Each released version is published to [open-workflow-specification.github.io/editor](https://open-workflow-specification.github.io/editor/), built from its git tag. Unlike the Netlify previews, this only ever shows what has been released to npm
 - **Dependency Updates**: Automated via Dependabot
 - **License Header Checks**: Apache 2.0 headers verified on all source files
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -39,10 +39,49 @@ On merge, the publish workflow automatically (no manual action needed):
 - Builds and tests packages
 - Publishes to npm
 - Creates git tags and GitHub releases
+- Deploys the Storybook to GitHub Pages, built from the new tag
 
 Check CI run at: [https://github.com/open-workflow-specification/editor/actions/workflows/publish-release.yaml](https://github.com/open-workflow-specification/editor/actions/workflows/publish-release.yaml)  
 GH Releases: [https://github.com/open-workflow-specification/editor/releases](https://github.com/open-workflow-specification/editor/releases)  
-NPM publishing at: [https://www.npmjs.com/package/@openworkflowspec/diagram-editor?activeTab=versions](https://www.npmjs.com/package/@openworkflowspec/diagram-editor?activeTab=versions)
+NPM publishing at: [https://www.npmjs.com/package/@openworkflowspec/diagram-editor?activeTab=versions](https://www.npmjs.com/package/@openworkflowspec/diagram-editor?activeTab=versions)  
+GitHub Pages: [https://open-workflow-specification.github.io/editor/](https://open-workflow-specification.github.io/editor/)
+
+---
+
+# GitHub Pages Deployment
+
+Every release is published to GitHub Pages by `.github/workflows/deploy-pages.yaml`, run as the
+final job of the publish workflow.
+
+## What gets deployed
+
+The Storybook build, made from the **git tag** just published — never from `main`. The deployed
+site therefore shows only what is on npm. Unreleased work on `main` keeps its Netlify preview
+(see `netlify.toml`) and never reaches Pages.
+
+## Layout
+
+Deployments live on the `gh-pages` branch and are permanent — nothing is ever deleted:
+
+```
+/                 redirects to /latest/
+/1.1.0/           permanent, immutable
+/1.2.0/
+/latest/          copy of the highest stable release
+```
+
+Link to `/latest/` for a URL that follows releases, or to a specific version for one that never
+changes.
+
+`latest` only ever moves **forward**: a patch released from a `1.0.x` maintenance branch does not
+overwrite a newer `latest`, and a prerelease never becomes `latest`.
+
+## Deploying a tag manually
+
+To backfill an older release or redeploy after a failed run, run the
+["Release :: Deploy to GitHub Pages"](https://github.com/open-workflow-specification/editor/actions/workflows/deploy-pages.yaml)
+workflow with the tag, e.g. `@openworkflowspec/diagram-editor@1.1.0`. Only tags are accepted —
+the workflow refuses a branch. Redeploying an already-published tag is safe.
 
 ---
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -41,47 +41,41 @@ On merge, the publish workflow automatically (no manual action needed):
 - Creates git tags and GitHub releases
 - Deploys the Storybook to GitHub Pages, built from the new tag
 
-Check CI run at: [https://github.com/open-workflow-specification/editor/actions/workflows/publish-release.yaml](https://github.com/open-workflow-specification/editor/actions/workflows/publish-release.yaml)  
-GH Releases: [https://github.com/open-workflow-specification/editor/releases](https://github.com/open-workflow-specification/editor/releases)  
-NPM publishing at: [https://www.npmjs.com/package/@openworkflowspec/diagram-editor?activeTab=versions](https://www.npmjs.com/package/@openworkflowspec/diagram-editor?activeTab=versions)  
+Check CI run at: [https://github.com/open-workflow-specification/editor/actions/workflows/publish-release.yaml](https://github.com/open-workflow-specification/editor/actions/workflows/publish-release.yaml)
+GH Releases: [https://github.com/open-workflow-specification/editor/releases](https://github.com/open-workflow-specification/editor/releases)
+NPM publishing at: [https://www.npmjs.com/package/@openworkflowspec/diagram-editor?activeTab=versions](https://www.npmjs.com/package/@openworkflowspec/diagram-editor?activeTab=versions)
 GitHub Pages: [https://open-workflow-specification.github.io/editor/](https://open-workflow-specification.github.io/editor/)
 
 ---
 
 # GitHub Pages Deployment
 
-Every release is published to GitHub Pages by `.github/workflows/deploy-pages.yaml`, run as the
-final job of the publish workflow.
+Every release is published to GitHub Pages by `.github/workflows/deploy-pages.yaml`, run as the final job of the publish workflow.
 
 ## What gets deployed
 
-The Storybook build, made from the **git tag** just published — never from `main`. The deployed
-site therefore shows only what is on npm. Unreleased work on `main` keeps its Netlify preview
-(see `netlify.toml`) and never reaches Pages.
+The Storybook build, made from the **git tag** just published — never from `main`. The deployed site therefore shows only what is on npm. Unreleased work on `main` keeps its Netlify preview (see `netlify.toml`) and never reaches Pages.
 
 ## Layout
 
 Deployments live on the `gh-pages` branch and are permanent — nothing is ever deleted:
 
 ```
-/                 redirects to /latest/
+/                 redirects to /latest/ (or, before any stable release
+                  exists, to the version just deployed)
 /1.1.0/           permanent, immutable
 /1.2.0/
 /latest/          copy of the highest stable release
 ```
 
-Link to `/latest/` for a URL that follows releases, or to a specific version for one that never
-changes.
+Link to `/latest/` for a URL that follows releases, or to a specific version for one that never changes.
 
-`latest` only ever moves **forward**: a patch released from a `1.0.x` maintenance branch does not
-overwrite a newer `latest`, and a prerelease never becomes `latest`.
+`latest` only ever moves **forward**: a patch released from a `1.0.x` maintenance branch does not overwrite a newer `latest`, and a prerelease never becomes `latest`.
 
 ## Deploying a tag manually
 
-To backfill an older release or redeploy after a failed run, run the
-["Release :: Deploy to GitHub Pages"](https://github.com/open-workflow-specification/editor/actions/workflows/deploy-pages.yaml)
-workflow with the tag, e.g. `@openworkflowspec/diagram-editor@1.1.0`. Only tags are accepted —
-the workflow refuses a branch. Redeploying an already-published tag is safe.
+To backfill an older release or redeploy after a failed run, run the ["Release :: Deploy to GitHub Pages"](https://github.com/open-workflow-specification/editor/actions/workflows/deploy-pages.yaml)
+workflow with the tag, e.g. `@openworkflowspec/diagram-editor@1.1.0`. Only tags are accepted — the workflow refuses a branch. Redeploying an already-published tag is safe.
 
 ---
 

--- a/packages/open-workflow-diagram-editor/README.md
+++ b/packages/open-workflow-diagram-editor/README.md
@@ -18,6 +18,8 @@
 
 Official visual diagram editor for the [Open Workflow Specification](https://github.com/open-workflow-specification/specification). A vendor-neutral, embeddable React component with strict separation between core logic and platform APIs.
 
+**[Try the editor](https://open-workflow-specification.github.io/editor/latest/)** — the latest released version.
+
 ## Getting Started
 
 ### Requirements
@@ -30,7 +32,7 @@ npm install react@^19 react-dom@^19
 
 ## Non-React Usage
 
-If your application doesn't use React, you can embed the editor as a Web Component.  
+If your application doesn't use React, you can embed the editor as a Web Component.
 See the [Vanilla Web Component example](https://github.com/open-workflow-specification/editor/tree/main/examples/vanilla-web-component) for a working setup.
 
 ## Installation


### PR DESCRIPTION
Closes https://github.com/open-workflow-specification/editor/issues/387

### Summary
Deploys released Editor versions to GitHub Pages, built from the exact git tag rather than `main`, so the published site only ever shows what is on npm. Netlify continues to preview unreleased work on `main` and PRs - unchanged.

###  Changes

- `.github/workflows/deploy-pages.yaml` - Builds a tag's Storybook and publishes it to `gh-pages`. `workflow_call` (from the release pipeline) + `workflow_dispatch` (manual backfill/redeploy). Refuses any ref that isn't a tag.
- `.github/workflows/publish-release.yaml` - Adds job outputs and a `deploy-pages` job gated on `published == 'true'`, so Pages only moves when npm does. 
- Update READMEs

## Testing

Verified end to end on a fork - **live site: https://lornakelly.github.io/editor/latest**

Three deploys run in sequence, deliberately ending with an *older* version to prove `latest` cannot regress:

| # | Deployed | Run | Result |
|---|---|---|---|
| 1 | `1.0.0` | [34121279838](https://github.com/lornakelly/editor/actions/runs/34121279838) | `No gh-pages yet -- creating it.` → `latest -> 1.0.0` |
| 2 | `1.1.0` | [34121471984](https://github.com/lornakelly/editor/actions/runs/34121471984) | `Existing gh-pages checked out.` → `latest -> 1.1.0` |
| 3 | `1.0.0` again | [34130155484](https://github.com/lornakelly/editor/actions/runs/34130155484) | `Keeping latest at 1.1.0 (1.0.0 is older).` |

### Non-tag refs are rejected

[Run 34130393637](https://github.com/lornakelly/editor/actions/runs/34130393637) fails at **Verify the ref is a tag**:

##[error]'tagged-tip' is not a git tag. Only released tags may be deployed.


### Other

- All routes serve 200: `/`, `/latest/`, `/1.0.0/`, `/1.1.0/`
- The deployed Storybook contains only what existed at that tag — the Undo/Redo story added to `main` after 1.1.0 does not appear
- 
## After merge

1. Deploy the current release (creates `gh-pages`):
   ```bash
   gh workflow run deploy-pages.yaml -R open-workflow-specification/editor \
     -f ref="@openworkflowspec/diagram-editor@1.1.0"
2. Enable Pages: Settings → Pages → Source Deploy from a branch > gh-pages > / (root).
3. Verify https://open-workflow-specification.github.io/editor/latest/ returns to 200.
