### PR TITLE
feat: DCO - enable remediation commits

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,22 @@
+#
+# Copyright 2021-Present The Open Workflow Specification Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Individual remediation lets a contributor add their own sign-off to a
+# commit retroactively, without rewriting history. Needed because GitHub's
+# squash merge re-authors commits from the account's display name and email,
+# which can differ from the Signed-off-by copied from the original commit.
+allowRemediationCommits:
+  individual: true


### PR DESCRIPTION
### Summary

Closes https://github.com/open-workflow-specification/editor/issues/412

Add a `.github/dco.yml` configuration file for the DCO GitHub App that enables individual remediation commits (see docs https://github.com/cncf/dco2#remediation-commits)

This lets a contributor retroactively add a Signed-off-by for one of their own commits via a follow-up commit that names the target commit by full SHA, instead of rewriting history.

 "Squash and merge" writes a brand-new commit and stamps its author from the contributor's GitHub account - their display name, and their account email- while copying the Signed-off-by trailer verbatim from the original local commit. Where those identities differ in either the name or the email, the resulting commit's sign-off no longer matches its own author, and it fails the DCO check the next time that commit turns up inside a pull request's commit range.

Enabling individual remediation gives a contributor a way to repair their own sign-off in place.